### PR TITLE
Test for writes after implicit flush

### DIFF
--- a/tests/general/pio_buf_lim_tests.F90.in
+++ b/tests/general/pio_buf_lim_tests.F90.in
@@ -1,3 +1,8 @@
+#ifndef NO_C_SIZEOF
+#define TYPE_SIZEOF(x) (C_SIZEOF(x)/SIZE(x))
+#else
+#define TYPE_SIZEOF(x) (SIZE(TRANSFER(x,bbuf))/SIZE(x))
+#endif
 ! Get the iobuf size
 ! lbuf_sz -> local buffer size
 ! lbuf_type_sz -> local buffer type size
@@ -112,9 +117,6 @@ PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME 
 PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
 #ifndef NO_C_SIZEOF
   use iso_c_binding, only : C_SIZEOF
-#define TYPE_SIZEOF(x) (C_SIZEOF(x)/SIZE(x))
-#else
-#define TYPE_SIZEOF(x) (SIZE(TRANSFER(x,bbuf))/SIZE(x))
 #endif
   implicit none
   integer, parameter :: VEC_LOCAL_SZ = 7
@@ -355,3 +357,137 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
 
   call PIO_freedecomp(pio_tf_iosystem_, iodesc)
 PIO_TF_AUTO_TEST_SUB_END nc_wr_mvar_impl_flush
+
+! Test that writes out two variables with implicit flush. Then
+! a third variable is written out (after the implicit flush).
+! The data corresponding to the third variable is only synced
+! when PIO_syncfile() is called (explicit flush).
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_after_impl_flush
+#ifndef NO_C_SIZEOF
+  use iso_c_binding, only : C_SIZEOF
+#endif
+  implicit none
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  integer(kind=pio_offset_kind) :: iobuf_sz
+  integer :: type_sz
+  type(var_desc_t)  :: pio_var1, pio_var2, pio_var3
+  character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1'
+  character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2'
+  character(len=*), parameter :: PIO_VAR3_NAME = 'PIO_TF_test_var3'
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: iodesc
+  integer, dimension(VEC_LOCAL_SZ) :: compdof, compdof_rel_disps
+  PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: wbuf, rbuf
+  byte, dimension(VEC_LOCAL_SZ) :: bbuf
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  type_sz = TYPE_SIZEOF(wbuf)
+
+  do i=1,VEC_LOCAL_SZ
+    compdof_rel_disps(i) = i
+  end do
+  dims(1) = VEC_LOCAL_SZ * pio_tf_world_sz_
+  compdof = VEC_LOCAL_SZ * pio_tf_world_rank_ + compdof_rel_disps
+  wbuf = pio_tf_world_rank_;
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, iodesc)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_wr_aftr_impl_flush_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR1_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var1 : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR2_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var2 : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR3_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var3)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var3 : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! ============ Flush every 2 vars ======================
+    call get_iobuf_sz(size(wbuf), type_sz, 2, iobuf_sz)
+    call PIO_set_buffer_size_limit(iobuf_sz)
+    PIO_TF_LOG(0,*) "Testing : Flush every 2 vars : buffer limit = ", iobuf_sz
+
+    ! Write two variables
+    call PIO_write_darray(pio_file, pio_var1, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var1) : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var2, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var2) : " // trim(filename))
+
+    ! The implicit flush should happen for the previous
+    ! two variables inside the next PIO_write_darray() call
+    !
+    ! Write out another variable, the data for pio_var3 is not
+    ! flushed out until we explicitly sync/close
+    call PIO_write_darray(pio_file, pio_var3, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var3) : " // trim(filename))
+
+    ! Sync data for all three variables (only results in explicit
+    ! flush of data corresponding to pio_var3, the third variable)
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR3_NAME, pio_var3)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var3 : " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var1, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray(var1) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var 1)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var2, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray(var2) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var 2)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var3, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray(var3) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var 3)")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, iodesc)
+PIO_TF_AUTO_TEST_SUB_END nc_wr_after_impl_flush


### PR DESCRIPTION
This test writes out a variable after an implicit
flush is invoked (internally in PIO) for the
previous variables.
