### PR TITLE
Set PIO buffer cache limit and cleanup bget

### DIFF
--- a/src/clib/bget.c
+++ b/src/clib/bget.c
@@ -717,8 +717,7 @@ void bpoolrelease()
 
 /*  BGET  --  Allocate a buffer.  */
 
-void *bget(requested_size)
-bufsize requested_size;
+void *bget(bufsize requested_size)
 {
     bufsize size = requested_size;
     struct bfhead *b;
@@ -930,8 +929,7 @@ bufsize requested_size;
     the  entire  contents  of  the buffer to zero, not just the
     region requested by the caller. */
 
-void *bgetz(size)
-bufsize size;
+void *bgetz(bufsize size)
 {
     char *buf = (char *) bget(size);
 
@@ -960,9 +958,7 @@ bufsize size;
     enhanced to allow the buffer to grow into adjacent free
     blocks and to avoid moving data unnecessarily.  */
 
-void *bgetr(buf, size)
-void *buf;
-bufsize size;
+void *bgetr(void *buf, bufsize size)
 {
     void *nbuf;
     bufsize osize;                    /* Old size of buffer */
@@ -1002,8 +998,7 @@ bufsize size;
 
 /*  BREL  --  Release a buffer.  */
 
-void brel(buf)
-void *buf;
+void brel(void *buf)
 {
     struct bfhead *b, *bn;
 
@@ -1166,11 +1161,11 @@ void *buf;
 
 /*  BECTL  --  Establish automatic pool expansion control  */
 
-void bectl(compact, acquire, release, pool_incr)
-    int (*compact)(bufsize sizereq, int sequence);
-void *(*acquire)(bufsize size);
-void (*release)(void *buf);
-bufsize pool_incr;
+void bectl(
+  int (*compact)(bufsize sizereq, int sequence),
+  void *(*acquire)(bufsize size),
+  void (*release)(void *buf),
+  bufsize pool_incr)
 {
     compfcn = compact;
     acqfcn = acquire;
@@ -1181,9 +1176,7 @@ bufsize pool_incr;
 
 /*  BPOOL  --  Add a region of memory to the buffer pool.  */
 
-void bpool(buf, len)
-void *buf;
-bufsize len;
+void bpool(void *buf, bufsize len)
 {
 #if PIO_USE_MALLOC
     pio_use_malloc_totavail += len;
@@ -1289,9 +1282,8 @@ void bfreespace(bufsize *totfree, bufsize *maxfree)
 
 /*  BSTATS  --  Return buffer allocation free space statistics.  */
 
-void bstats(curalloc, totfree, maxfree, nget, nrel)
-    bufsize *curalloc, *totfree, *maxfree;
-long *nget, *nrel;
+void bstats(bufsize *curalloc, bufsize *totfree,
+    bufsize *maxfree, long *nget, long *nrel)
 {
     *nget = numget;
     *nrel = numrel;
@@ -1303,9 +1295,8 @@ long *nget, *nrel;
 
 /*  BSTATSE  --  Return extended statistics  */
 
-void bstatse(pool_incr, npool, npget, nprel, ndget, ndrel)
-bufsize *pool_incr;
-long *npool, *npget, *nprel, *ndget, *ndrel;
+void bstatse(bufsize *pool_incr,
+  long *npool, long *npget, long *nprel, long *ndget, long *ndrel)
 {
     *pool_incr = (pool_len < 0) ? -exp_incr : exp_incr;
     *npool = numpblk;
@@ -1323,8 +1314,7 @@ long *npool, *npget, *nprel, *ndget, *ndrel;
     data pointer, and backs up to the buffer header.  It will
     dump either a free block or an allocated one.       */
 
-void bufdump(buf)
-void *buf;
+void bufdump(void *buf)
 {
     struct bfhead *b;
     unsigned char *bdump;
@@ -1383,9 +1373,7 @@ void *buf;
     dumped as well.  If FreeWipe  checking      is  enabled,  free
     blocks      which  have  been clobbered will always be dumped. */
 
-void bpoold(buf, dumpalloc, dumpfree)
-void *buf;
-int dumpalloc, dumpfree;
+void bpoold(void *buf, int dumpalloc, int dumpfree)
 {
     struct bfhead *b = BFH(buf);
 
@@ -1432,8 +1420,7 @@ int dumpalloc, dumpfree;
 /*  BPOOLV  --  Validate a buffer pool.  If NDEBUG isn't defined,
     any error generates an assertion failure.  */
 
-int bpoolv(buf)
-void *buf;
+int bpoolv(void *buf)
 {
     struct bfhead *b = BFH(buf);
 
@@ -1530,8 +1517,7 @@ int rand()
 
 /* Set seed for random generator */
 
-void srand(seed)
-unsigned int seed;
+void srand(unsigned int seed)
 {
     next = seed;
 }
@@ -1539,8 +1525,7 @@ unsigned int seed;
 
 /*  STATS  --  Edit statistics returned by bstats() or bstatse().  */
 
-static void stats(when)
-char *when;
+static void stats(char *when)
 {
     bufsize cural, totfree, maxfree;
     long nget, nfree;
@@ -1567,9 +1552,7 @@ static int protect = 0;               /* Disable compaction during bgetr() */
 
 /*  BCOMPACT  --  Compaction call-back function.  */
 
-static int bcompact(bsize, seq)
-bufsize bsize;
-int seq;
+static int bcompact(bufsize bsize, int seq)
 {
 #ifdef CompactTries
     char *bc = bchain;
@@ -1614,8 +1597,7 @@ int seq;
 
 /*  BEXPAND  --  Expand pool call-back function.  */
 
-static void *bexpand(size)
-bufsize size;
+static void *bexpand(bufsize size)
 {
     void *np = NULL;
     bufsize cural, totfree, maxfree;
@@ -1637,8 +1619,7 @@ bufsize size;
 
 /*  BSHRINK  --  Shrink buffer pool call-back function.  */
 
-static void bshrink(buf)
-void *buf;
+static void bshrink(void *buf)
 {
     if (((char *) buf) == bp) {
 #ifdef EXPTRACE
@@ -1657,8 +1638,7 @@ void *buf;
 /*  Restrict buffer requests to those large enough to contain our pointer and
     small enough for the CPU architecture.  */
 
-static bufsize blimit(bs)
-bufsize bs;
+static bufsize blimit(bufsize bs)
 {
     if (bs < sizeof(char *)) {
         bs = sizeof(char *);

--- a/src/clib/bget.c
+++ b/src/clib/bget.c
@@ -535,9 +535,9 @@ static long numdget = 0, numdrel = 0; /* Number of direct gets and rels */
 
 /* Automatic expansion block management functions */
 
-static int (*compfcn) _((bufsize sizereq, int sequence)) = NULL;
-static void *(*acqfcn) _((bufsize size)) = NULL;
-static void (*relfcn) _((void *buf)) = NULL;
+static int (*compfcn)(bufsize sizereq, int sequence) = NULL;
+static void *(*acqfcn)(bufsize size) = NULL;
+static void (*relfcn)(void *buf) = NULL;
 
 static bufsize exp_incr = 0;          /* Expansion block size */
 static bufsize pool_len = 0;          /* 0: no bpool calls have been made
@@ -1167,9 +1167,9 @@ void *buf;
 /*  BECTL  --  Establish automatic pool expansion control  */
 
 void bectl(compact, acquire, release, pool_incr)
-    int (*compact) _((bufsize sizereq, int sequence));
-void *(*acquire) _((bufsize size));
-void (*release) _((void *buf));
+    int (*compact)(bufsize sizereq, int sequence);
+void *(*acquire)(bufsize size);
+void (*release)(void *buf);
 bufsize pool_incr;
 {
     compfcn = compact;

--- a/src/clib/bget.h
+++ b/src/clib/bget.h
@@ -11,31 +11,23 @@
 //#undef NDEBUG
 //#endif
 
-#ifndef _
-#ifdef PROTOTYPES
-#define  _(x)  x                      /* If compiler knows prototypes */
-#else
-#define  _(x)  ()                     /* It it doesn't */
-#endif /* PROTOTYPES */
-#endif
-
 typedef long bufsize;
-void    bpool       _((void *buffer, bufsize len));
-void   *bget        _((bufsize size));
-void   *bgetz       _((bufsize size));
-void   *bgetr       _((void *buffer, bufsize newsize));
-void    brel        _((void *buf));
-void    bectl       _((int (*compact)(bufsize sizereq, int sequence),
+void    bpool(void *buffer, bufsize len);
+void   *bget(bufsize size);
+void   *bgetz(bufsize size);
+void   *bgetr(void *buffer, bufsize newsize);
+void    brel(void *buf);
+void    bectl(int (*compact)(bufsize sizereq, int sequence),
                        void *(*acquire)(bufsize size),
-                       void (*release)(void *buf), bufsize pool_incr));
-void    bstats      _((bufsize *curalloc, bufsize *totfree, bufsize *maxfree,
-                       long *nget, long *nrel));
-void    bstatse     _((bufsize *pool_incr, long *npool, long *npget,
-                       long *nprel, long *ndget, long *ndrel));
-void    bufdump     _((void *buf));
-void    bpoold      _((void *pool, int dumpalloc, int dumpfree));
-int     bpoolv      _((void *pool));
-void bpoolrelease  _();
-void bfreespace  _((bufsize *maxfree, bufsize *totfree));
+                       void (*release)(void *buf), bufsize pool_incr);
+void    bstats(bufsize *curalloc, bufsize *totfree, bufsize *maxfree,
+                       long *nget, long *nrel);
+void    bstatse(bufsize *pool_incr, long *npool, long *npget,
+                       long *nprel, long *ndget, long *ndrel);
+void    bufdump(void *buf);
+void    bpoold(void *pool, int dumpalloc, int dumpfree);
+int     bpoolv(void *pool);
+void bpoolrelease();
+void bfreespace(bufsize *maxfree, bufsize *totfree);
 
 #endif

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -765,9 +765,12 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 #endif /* PIO_ENABLE_LOGGING */
 #endif /* !PIO_USE_MALLOC */
 
-        /* If needsflush == 2 flush to disk otherwise just flush to io
-         * node. This will cause PIOc_write_darray_multi() to be
-         * called. */
+        /* Flush buffer to I/O processes - rearrange data and
+         * start writing data from the I/O processes
+         * Note : Setting the last flag in flush_buffer to
+         * true will force flush the buffer to disk for all
+         * iotypes (wait for write to complete for PnetCDF)
+         */
         if ((ierr = flush_buffer(ncid, wmb, (needsflush == 2))))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
     }

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -692,7 +692,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* Try realloc first and call flush if realloc fails. */
     if (arraylen > 0)
     {
-        realloc_data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size);
+        realloc_data = bgetr(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size);
         if (realloc_data)
         {
             needsflush = 0;
@@ -772,7 +772,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* Try realloc again if there is a flush. */
     if (arraylen > 0 && needsflush > 0)
     {
-        if (!(wmb->data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size)))
+        if (!(wmb->data = bgetr(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size)))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
         LOG((2, "after a flush, realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
     }

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -52,7 +52,9 @@ void bpool_free(void *p)
  */
 int compute_buffer_init(iosystem_desc_t *ios)
 {
-#if !PIO_USE_MALLOC
+#if PIO_USE_MALLOC
+    bpool(NULL, pio_cnbuffer_limit);
+#else
 
     if (!CN_bpool)
     {
@@ -65,7 +67,7 @@ int compute_buffer_init(iosystem_desc_t *ios)
 
         bectl(NULL, malloc, bpool_free, pio_cnbuffer_limit);
     }
-#endif
+#endif /* PIO_USE_MALLOC */
     LOG((2, "compute_buffer_init complete"));
 
     return PIO_NOERR;

--- a/tests/general/pio_buf_lim_tests.F90.in
+++ b/tests/general/pio_buf_lim_tests.F90.in
@@ -120,10 +120,11 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
   integer, parameter :: VEC_LOCAL_SZ = 7
   integer(kind=pio_offset_kind) :: iobuf_sz
   integer :: type_sz
-  type(var_desc_t)  :: pio_var1, pio_var2, pio_var3
+  type(var_desc_t)  :: pio_var1, pio_var2, pio_var3, pio_var4
   character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1'
   character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2'
   character(len=*), parameter :: PIO_VAR3_NAME = 'PIO_TF_test_var3'
+  character(len=*), parameter :: PIO_VAR4_NAME = 'PIO_TF_test_var4'
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
   type(io_desc_t) :: iodesc
@@ -169,45 +170,33 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
     ierr = PIO_def_var(pio_file, PIO_VAR3_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var3)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var3 : " // trim(filename))
 
+    ierr = PIO_def_var(pio_file, PIO_VAR4_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var4)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var4 : " // trim(filename))
+
     ierr = PIO_enddef(pio_file)
     PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
 
+    ! Set the buffer size limit such that we trigger an implicit flush
+    ! on the next write. To flush every var set the buffer size limit
+    ! to be slightly less than the size (local) required to cache a
+    ! single variable. When the second variable is written out the first
+    ! variable will be flushed out (since internal cache >= buffer size limit)
+
     ! ============ Flush every var ======================
+    ! Before the 2nd variable is written out the data
+    ! corresponding to the first variable will be flushed out
+
+    ! Set the buffer size limit to be slightly less than required
+    ! for a single variable
     call get_iobuf_sz(size(wbuf), type_sz, 1, iobuf_sz)
     call PIO_set_buffer_size_limit(iobuf_sz)
-    PIO_TF_LOG(0,*) "Testing : Flush every var : buffer limit = ", iobuf_sz
+    PIO_TF_LOG(0,*) "Testing : Flush every 1 var : buffer limit = ", iobuf_sz
 
     ! Write the variable out
     call PIO_write_darray(pio_file, pio_var1, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var1) : " // trim(filename))
 
-#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
-    call PIO_closefile(pio_file)
-
-    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
-    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
-
-    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
-    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 : " // trim(filename))
-#else
-    call PIO_syncfile(pio_file)
-#endif
-
-    rbuf = 0
-    call PIO_read_darray(pio_file, pio_var1, iodesc, rbuf, ierr)
-    PIO_TF_CHECK_ERR(ierr, "Failed to read darray(var1) : " // trim(filename))
-
-    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val")
-
-    ! ============ Flush every 2 vars ======================
-    call get_iobuf_sz(size(wbuf), type_sz, 2, iobuf_sz)
-    call PIO_set_buffer_size_limit(iobuf_sz)
-    PIO_TF_LOG(0,*) "Testing : Flush every 2 vars : buffer limit = ", iobuf_sz
-
-    ! Write the variable out
-    call PIO_write_darray(pio_file, pio_var1, iodesc, wbuf, ierr)
-    PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var1) : " // trim(filename))
-
+    ! Flush for the first variable should happen inside PIO_write_darray(pio_var2)
     call PIO_write_darray(pio_file, pio_var2, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var2) : " // trim(filename))
 
@@ -238,10 +227,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
 
     PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var 2)")
 
-    ! ============ Flush every 3 vars ======================
-    call get_iobuf_sz(size(wbuf), type_sz, 3, iobuf_sz)
+    ! ============ Flush every 2 vars ======================
+    call get_iobuf_sz(size(wbuf), type_sz, 2, iobuf_sz)
     call PIO_set_buffer_size_limit(iobuf_sz)
-    PIO_TF_LOG(0,*) "Testing : Flush every 3 vars : buffer limit = ", iobuf_sz
+    PIO_TF_LOG(0,*) "Testing : Flush every 2 vars : buffer limit = ", iobuf_sz
 
     ! Write the variable out
     call PIO_write_darray(pio_file, pio_var1, iodesc, wbuf, ierr)
@@ -250,6 +239,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
     call PIO_write_darray(pio_file, pio_var2, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var2) : " // trim(filename))
 
+    ! Flush for the previous 2 vars, pio_var1 and pio_var2 should happen
+    ! inside PIO_write_darray(pio_var3)
     call PIO_write_darray(pio_file, pio_var3, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var3) : " // trim(filename))
 
@@ -288,6 +279,71 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray(var3) : " // trim(filename))
 
     PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var 3)")
+
+    ! ============ Flush every 3 vars ======================
+    call get_iobuf_sz(size(wbuf), type_sz, 3, iobuf_sz)
+    call PIO_set_buffer_size_limit(iobuf_sz)
+    PIO_TF_LOG(0,*) "Testing : Flush every 3 vars : buffer limit = ", iobuf_sz
+
+    ! Write the variable out
+    call PIO_write_darray(pio_file, pio_var1, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var1) : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var2, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var2) : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var3, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var3) : " // trim(filename))
+
+    ! Flush for the previous 3 vars, pio_var1, pio_var2, pio_var3 should happen
+    ! inside PIO_write_darray(pio_var4)
+    call PIO_write_darray(pio_file, pio_var4, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var4) : " // trim(filename))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR3_NAME, pio_var3)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var3 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR4_NAME, pio_var4)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var4 : " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var1, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray(var1) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var 1)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var2, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray(var2) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var 2)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var3, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray(var3) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var 3)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var4, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray(var4) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var 4)")
 
     call PIO_closefile(pio_file)
     call PIO_deletefile(pio_tf_iosystem_, filename);


### PR DESCRIPTION
This merge brings in changes to,

* Set PIO write buffer cache limit using pio_set_buffer_size_limit(limit)
* Some enhancements to bget memory management when malloc() is
  used to store memory statistics
* Some cleanup of bget() code to remove support for old-style C

Fixes #86 
Fixes #87  
Fixes #88 

