### PR TITLE
Add data type conversions support for ADIOS IO type

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -571,6 +571,71 @@ static void PIOc_write_decomp_adios(file_desc_t *file, int ioid)
     }
 }
 
+#define ADIOS_CONVERT_ARRAY(array,arraylen,from_type,to_type,ierr,buf) \
+{ \
+	from_type *d = (from_type*)array; \
+	to_type *f   = (to_type*)malloc(arraylen*sizeof(to_type)); \
+	if (f) { \
+		for (int i=0; i<arraylen; ++i) \
+			f[i] = (to_type)d[i]; \
+		buf = f; \
+	} else { \
+		ierr = 1; \
+	} \
+}
+
+#define ADIOS_CONVERT_FROM_TO(FROM_TYPE_ID,from_type) \
+{ \
+   	if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_DOUBLE) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,double,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_FLOAT) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,float,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_REAL) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,float,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_INT) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,int,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_UINT) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,unsigned int,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_SHORT) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,short int,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_USHORT) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,unsigned short int,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_INT64) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,int64_t,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_UINT64) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,uint64_t,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_CHAR) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,char,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_BYTE) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,char,*ierr,buf); \
+	} else if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_UBYTE) { \
+		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,unsigned char,*ierr,buf); \
+	} \
+}
+
+static void *PIOc_convert_buffer_adios(file_desc_t *file, io_desc_t *iodesc, 
+								adios_var_desc_t *av, void *array, int arraylen, 
+								int *ierr) 
+{
+	void *buf = array;
+	*ierr = 0;
+
+	ADIOS_CONVERT_FROM_TO(PIO_DOUBLE,double);
+	ADIOS_CONVERT_FROM_TO(PIO_FLOAT,float);
+	ADIOS_CONVERT_FROM_TO(PIO_REAL,float);
+	ADIOS_CONVERT_FROM_TO(PIO_INT,int);
+	ADIOS_CONVERT_FROM_TO(PIO_UINT,unsigned int);
+	ADIOS_CONVERT_FROM_TO(PIO_SHORT,short int);
+	ADIOS_CONVERT_FROM_TO(PIO_USHORT,unsigned short int);
+	ADIOS_CONVERT_FROM_TO(PIO_INT64,int64_t);
+	ADIOS_CONVERT_FROM_TO(PIO_UINT64,uint64_t);
+	ADIOS_CONVERT_FROM_TO(PIO_CHAR,char);
+	ADIOS_CONVERT_FROM_TO(PIO_BYTE,char);
+	ADIOS_CONVERT_FROM_TO(PIO_UBYTE,unsigned char);
+
+	return buf;
+}
+
 static int PIOc_write_darray_adios(
         file_desc_t *file, int varid, int ioid, io_desc_t *iodesc,
         PIO_Offset arraylen, void *array, void *fillvalue)
@@ -587,6 +652,7 @@ static int PIOc_write_darray_adios(
         sprintf(ldims, "%lld", arraylen);
         enum ADIOS_DATATYPES atype = av->adios_type;
 
+#if 0 /* Will always convert from iodesc->piotype to av->nc_type */
         /* ACME history data special handling: down-conversion from double to float */
         if (iodesc->piotype != av->nc_type)
         {
@@ -616,6 +682,7 @@ static int PIOc_write_darray_adios(
                             av->nc_type));
             }
         }
+#endif
 
         av->adios_varid = adios_define_var(file->adios_group, av->name, "", atype, ldims,"","");
 
@@ -651,23 +718,10 @@ static int PIOc_write_darray_adios(
     int buf_needs_free = 0;
     if (iodesc->piotype != av->nc_type)
     {
-        if (iodesc->piotype == PIO_DOUBLE && av->nc_type == PIO_FLOAT)
-        {
-            double *d = (double *)array;
-            float *f = (float *)malloc(arraylen*sizeof(float));
-            if (f)
-            {
-                for (int i=0; i<arraylen; ++i)
-                {
-                    f[i] = (float)d[i];
-                }
-                buf = f;
-                buf_needs_free = 1;
-            }
-            else
-            {
+		buf = PIOc_convert_buffer_adios(file,iodesc,av,array,arraylen,&ierr);
+		if (ierr!=0) {
 #ifdef _ADIOS_ALL_PROCS
-        		if (file->adios_iomaster == MPI_ROOT)
+       		if (file->adios_iomaster == MPI_ROOT)
 #else
             if (file->iosystem->iomaster == MPI_ROOT)
 #endif /* _ADIOS_ALL_PROCS */
@@ -675,24 +729,10 @@ static int PIOc_write_darray_adios(
                             "ADIOS cannot do type conversion because memory could not be allocated."
                             "Therefore the data will be corrupt for this variable in the .bp output\n",
                             file->adios_vars[varid].name));
-            }
-        }
+        } else {
+			buf_needs_free = 1;
+		}
     }
-
-#if 0
-    /* DEBUG printout */
-    if (!strcmp(file->adios_vars[varid].name,"foo"))
-    {
-        /* Print the first few longitude values */
-        float *lon = (float*)buf;
-        printf("Values of '%s' addr %p..%p: [ ", file->adios_vars[varid].name, (float*)buf, ((float*)buf)+10);
-        for (int i=0; i<10; i++)
-        {
-            printf("%6.3f ", lon[i]);
-        }
-        printf("\n");
-    }
-#endif
 
     adios_write_byid(file->adios_fh, av->adios_varid, buf);
 


### PR DESCRIPTION
When pio_initdecomp uses a piotype that is different from the
nc_type used in pio_def_var, an implicit data type conversion
needs to be performed (double to float, float to int, etc).

This patch (provided by Tahsin Kurc) is picked from adios_support
branch in ornladios repo.

Without this fix, some Fortran unit tests on implicit data type
conversion fail when ADIOS IO type is used.