### PR TITLE
Define variables (no write operations) for ADIOS IO type

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -584,7 +584,7 @@ static void PIOc_write_decomp_adios(file_desc_t *file, int ioid)
 	} \
 }
 
-#define ADIOS_CONVERT_FROM_TO(FROM_TYPE_ID,from_type) \
+#define ADIOS_CONVERT_FROM(FROM_TYPE_ID,from_type) \
 { \
    	if (iodesc->piotype == FROM_TYPE_ID && av->nc_type == PIO_DOUBLE) { \
 		ADIOS_CONVERT_ARRAY(array,arraylen,from_type,double,*ierr,buf); \
@@ -620,18 +620,18 @@ static void *PIOc_convert_buffer_adios(file_desc_t *file, io_desc_t *iodesc,
 	void *buf = array;
 	*ierr = 0;
 
-	ADIOS_CONVERT_FROM_TO(PIO_DOUBLE,double);
-	ADIOS_CONVERT_FROM_TO(PIO_FLOAT,float);
-	ADIOS_CONVERT_FROM_TO(PIO_REAL,float);
-	ADIOS_CONVERT_FROM_TO(PIO_INT,int);
-	ADIOS_CONVERT_FROM_TO(PIO_UINT,unsigned int);
-	ADIOS_CONVERT_FROM_TO(PIO_SHORT,short int);
-	ADIOS_CONVERT_FROM_TO(PIO_USHORT,unsigned short int);
-	ADIOS_CONVERT_FROM_TO(PIO_INT64,int64_t);
-	ADIOS_CONVERT_FROM_TO(PIO_UINT64,uint64_t);
-	ADIOS_CONVERT_FROM_TO(PIO_CHAR,char);
-	ADIOS_CONVERT_FROM_TO(PIO_BYTE,char);
-	ADIOS_CONVERT_FROM_TO(PIO_UBYTE,unsigned char);
+	ADIOS_CONVERT_FROM(PIO_DOUBLE,double);
+	ADIOS_CONVERT_FROM(PIO_FLOAT,float);
+	ADIOS_CONVERT_FROM(PIO_REAL,float);
+	ADIOS_CONVERT_FROM(PIO_INT,int);
+	ADIOS_CONVERT_FROM(PIO_UINT,unsigned int);
+	ADIOS_CONVERT_FROM(PIO_SHORT,short int);
+	ADIOS_CONVERT_FROM(PIO_USHORT,unsigned short int);
+	ADIOS_CONVERT_FROM(PIO_INT64,int64_t);
+	ADIOS_CONVERT_FROM(PIO_UINT64,uint64_t);
+	ADIOS_CONVERT_FROM(PIO_CHAR,char);
+	ADIOS_CONVERT_FROM(PIO_BYTE,char);
+	ADIOS_CONVERT_FROM(PIO_UBYTE,unsigned char);
 
 	return buf;
 }
@@ -652,38 +652,6 @@ static int PIOc_write_darray_adios(
         sprintf(ldims, "%lld", arraylen);
         enum ADIOS_DATATYPES atype = av->adios_type;
 
-#if 0 /* Will always convert from iodesc->piotype to av->nc_type */
-        /* ACME history data special handling: down-conversion from double to float */
-        if (iodesc->piotype != av->nc_type)
-        {
-            if (iodesc->piotype == PIO_DOUBLE && av->nc_type == PIO_FLOAT)
-            {
-#ifdef _ADIOS_ALL_PROCS
-                if (file->adios_iomaster == MPI_ROOT)
-#else
-                if (file->iosystem->iomaster == MPI_ROOT)
-#endif /* _ADIOS_ALL_PROCS */
-                    LOG((2,"Darray '%s' decomp type is %d (size=%d) but target type is %d. We need conversion\n",
-                            file->adios_vars[varid].name, iodesc->piotype, iodesc->piotype_size,
-                            av->nc_type));
-            }
-            else
-            {
-                atype = PIOc_get_adios_type(iodesc->piotype);
-#ifdef _ADIOS_ALL_PROCS
-                if (file->adios_iomaster == MPI_ROOT)
-#else
-                if (file->iosystem->iomaster == MPI_ROOT)
-#endif /* _ADIOS_ALL_PROCS */
-                    LOG((2,"Darray '%s' decomp type is %d (size=%d) but target type is %d. "
-                            "ADIOS cannot do type conversion and therefore the data will be "
-                            "corrupt for this variable when converting from .bp to .nc with adios2pio\n",
-                            file->adios_vars[varid].name, iodesc->piotype, iodesc->piotype_size,
-                            av->nc_type));
-            }
-        }
-#endif
-
         av->adios_varid = adios_define_var(file->adios_group, av->name, "", atype, ldims,"","");
 
 #ifdef _ADIOS_ALL_PROCS
@@ -691,15 +659,7 @@ static int PIOc_write_darray_adios(
 #else
         if (file->iosystem->iomaster == MPI_ROOT)
 #endif  /* _ADIOS_ALL_PROCS */
-        {
-            adios_define_attribute_byvalue(file->adios_group,"__pio__/ndims",av->name,adios_integer,1,&av->ndims);
-            adios_define_attribute_byvalue(file->adios_group,"__pio__/nctype",av->name,adios_integer,1,&av->nc_type);
-            char* dimnames[6];
-            for (int i = 0; i < av->ndims; i++)
-            {
-                dimnames[i] = file->dim_names[av->gdimids[i]];
-            }
-            adios_define_attribute_byvalue(file->adios_group,"__pio__/dims",av->name,adios_string_array,av->ndims,dimnames);
+        { /* TAHSIN: Some of the codes were moved to pio_nc.c */
             char decompname[32];
             sprintf(decompname, "%d", ioid);
             adios_define_attribute(file->adios_group, "__pio__/decomp", av->name, adios_string, decompname, NULL);

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2761,6 +2761,21 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
             *varidp = file->num_vars;
             file->num_vars++;
             ierr = 0;
+
+            /* TAHSIN -- some codes moved from pio_darray.c */
+            {
+                adios_var_desc_t * av = &(file->adios_vars[*varidp]);
+                if (file->adios_iomaster == MPI_ROOT)
+                {
+                    adios_define_attribute_byvalue(file->adios_group,"__pio__/ndims",av->name,adios_integer,1,&av->ndims);
+                    adios_define_attribute_byvalue(file->adios_group,"__pio__/nctype",av->name,adios_integer,1,&av->nc_type);
+                    char* dimnames[6];
+                    for (int i = 0; i < av->ndims; i++)
+                        dimnames[i] = file->dim_names[av->gdimids[i]];
+                    adios_define_attribute_byvalue(file->adios_group,"__pio__/dims",av->name,adios_string_array,av->ndims,dimnames);
+                }
+            }
+            /* TAHSIN */
     }
 #endif /* _ADIOS_ALL_PROCS */
 #endif


### PR DESCRIPTION
When there is no write operation on a variable, PIO_ADIOS does
not save the variable definition to the output bp files for the
conversion tool.

This patch (provided by Tahsin Kurc) is picked from adios_support
branch in ornladios repo.

Without this fix, a few Fortran unit tests fail due to some missing
variable definitions in the output files.