### PR TITLE
Update PIO_TF_Get_undef_iotypes/PIO_TF_Get_undef_nc_iotypes to return expected IO types

### DIFF
--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -350,10 +350,10 @@ CONTAINS
 #ifndef _NETCDF
       ! netcdf
       num_iotypes = num_iotypes + 1
-#ifndef _NETCDF4
-        ! netcdf4p, netcdf4c
-        num_iotypes = num_iotypes + 2
 #endif
+#ifndef _NETCDF4
+      ! netcdf4p, netcdf4c
+      num_iotypes = num_iotypes + 2
 #endif
 #ifndef _PNETCDF
       ! pnetcdf
@@ -365,26 +365,26 @@ CONTAINS
     ALLOCATE(iotype_descs(num_iotypes))
 
     i = 1
-#ifndef _PNETCDF
-      ! pnetcdf
-      iotypes(i) = PIO_iotype_pnetcdf
-      iotype_descs(i) = "PNETCDF"
-      i = i + 1
-#endif
 #ifndef _NETCDF
       ! netcdf
       iotypes(i) = PIO_iotype_netcdf
       iotype_descs(i) = "NETCDF"
       i = i + 1
-#ifndef _NETCDF4
-        ! netcdf4p, netcdf4c
-        iotypes(i) = PIO_iotype_netcdf4c
-        iotype_descs(i) = "NETCDF4C"
-        i = i + 1
-        iotypes(i) = PIO_iotype_netcdf4p
-        iotype_descs(i) = "NETCDF4P"
-        i = i + 1
 #endif
+#ifndef _NETCDF4
+      ! netcdf4p, netcdf4c
+      iotypes(i) = PIO_iotype_netcdf4c
+      iotype_descs(i) = "NETCDF4C"
+      i = i + 1
+      iotypes(i) = PIO_iotype_netcdf4p
+      iotype_descs(i) = "NETCDF4P"
+      i = i + 1
+#endif
+#ifndef _PNETCDF
+      ! pnetcdf
+      iotypes(i) = PIO_iotype_pnetcdf
+      iotype_descs(i) = "PNETCDF"
+      i = i + 1
 #endif
   END SUBROUTINE
 
@@ -467,10 +467,10 @@ CONTAINS
 #ifndef _NETCDF
       ! netcdf
       num_iotypes = num_iotypes + 1
+#endif
 #ifndef _NETCDF4
       ! netcdf4p, netcdf4c
       num_iotypes = num_iotypes + 2
-#endif
 #endif
 #ifndef _PNETCDF
       ! pnetcdf
@@ -487,11 +487,6 @@ CONTAINS
       iotypes(i) = PIO_iotype_netcdf
       iotype_descs(i) = "NETCDF"
       i = i + 1
-#ifndef _PNETCDF
-      ! pnetcdf
-      iotypes(i) = PIO_iotype_pnetcdf
-      iotype_descs(i) = "PNETCDF"
-      i = i + 1
 #endif
 #ifndef _NETCDF4
       ! netcdf4p, netcdf4c
@@ -502,6 +497,11 @@ CONTAINS
       iotype_descs(i) = "NETCDF4P"
       i = i + 1
 #endif
+#ifndef _PNETCDF
+      ! pnetcdf
+      iotypes(i) = PIO_iotype_pnetcdf
+      iotype_descs(i) = "PNETCDF"
+      i = i + 1
 #endif
   END SUBROUTINE
 


### PR DESCRIPTION
PIO_TF_Get_undef_iotypes returns wrong IO types for certain
NetCDF/PnetCDF configurations. PIO_TF_Get_undef_nc_iotypes
has the same issue.

The conditional compilation statements in these subroutines
need to be adjusted to get correct undefined IO types for
all possible configurations.

Fixes #119