### PR TITLE
Fix iotype_is_valid() for PIO configured without PnetCDF

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2403,7 +2403,7 @@ int pioc_change_def(int ncid, int is_enddef)
  * Check whether an IO type is valid for the build.
  *
  * @param iotype the IO type to check
- * @returns 0 if valid, non-zero otherwise.
+ * @returns 0 if not valid, non-zero otherwise.
  */
 int iotype_is_valid(int iotype)
 {
@@ -2421,9 +2421,9 @@ int iotype_is_valid(int iotype)
 #endif /* _NETCDF4 */
 
     /* Some builds include pnetcdf. */
+#ifdef _PNETCDF
     if (iotype == PIO_IOTYPE_PNETCDF)
         ret++;
-#ifdef _PNETCDF
 #endif /* _PNETCDF */
 
     return ret;


### PR DESCRIPTION
Adjust the conditional compilation statement for _PNETCDF such
that PIO_IOTYPE_PNETCDF is not valid when PIO is configured
and built without PnetCDF.

Also fix a typo in the Doxygen documentation of this function.

Fixes #121