### PR TITLE
Make NetCDF optional when PnetCDF is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option (PIO_USE_MALLOC       "Use native malloc (instead of bget package)"  OFF)
 option (PIO_MICRO_TIMING     "Enable internal micro timers"                 OFF)
 option (PIO_SAVE_DECOMPS     "Dump the decomposition information"           OFF)
 option (WITH_PNETCDF         "Require the use of PnetCDF"                   ON)
+option (WITH_NETCDF          "Require the use of NetCDF"                    ON)
 
 # Set a variable that appears in the config.h.in file.
 if(PIO_USE_MALLOC)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ If PnetCDF is not installed on the system, the user can disable its use by
 setting `-DWITH_PNETCDF=OFF`.  This will disable the search for PnetCDF on the
 system and disable the use of PnetCDF from within PIO.
 
+NetCDF is optional if PnetCDF is used, and the user can disable its use by
+setting `-DWITH_NETCDF=OFF`.  This will disable the search for NetCDF on the
+system and disable the use of NetCDF from within PIO.
+
 If the user wishes to disable the PIO tests, then the user can set the
 variable `-DPIO_ENABLE_TESTS=OFF`.  This will entirely disable the CTest 
 testing suite, as well as remove all of the test build targets.

--- a/doc/source/Installing.txt
+++ b/doc/source/Installing.txt
@@ -79,6 +79,10 @@ If PnetCDF is not installed on the system, the user can disable its use by
 setting `-DWITH_PNETCDF=OFF`.  This will disable the search for PnetCDF on the
 system and disable the use of PnetCDF from within PIO.
 
+NetCDF is optional if PnetCDF is used, and the user can disable its use by
+setting `-DWITH_NETCDF=OFF`.  This will disable the search for NetCDF on the
+system and disable the use of NetCDF from within PIO.
+
 If the user wishes to disable the PIO tests, then the user can set the
 variable `-DPIO_ENABLE_TESTS=OFF`.  This will entirely disable the CTest 
 testing suite, as well as remove all of the test build targets.

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -274,7 +274,9 @@ data:
 #ifdef _PNETCDF
         format[num_flavors++] = PIO_IOTYPE_PNETCDF;
 #endif
+#ifdef _NETCDF
         format[num_flavors++] = PIO_IOTYPE_NETCDF;
+#endif
 #ifdef _NETCDF4
         format[num_flavors++] = PIO_IOTYPE_NETCDF4C;
         format[num_flavors++] = PIO_IOTYPE_NETCDF4P;

--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -333,7 +333,9 @@ int check_file(int ntasks, char *filename) {
 #ifdef _PNETCDF
         format[num_flavors++] = PIO_IOTYPE_PNETCDF;
 #endif
+#ifdef _NETCDF
         format[num_flavors++] = PIO_IOTYPE_NETCDF;
+#endif
 #ifdef _NETCDF4
         format[num_flavors++] = PIO_IOTYPE_NETCDF4C;
         format[num_flavors++] = PIO_IOTYPE_NETCDF4P;

--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -81,7 +81,7 @@ int resultlen;
  *
  * @return 0 if example file is correct, non-zero otherwise. */
 int check_file(int ntasks, char *filename) {
-    
+#ifdef _NETCDF
     int ncid;         /**< File ID from netCDF. */
     int ndims;        /**< Number of dimensions. */
     int nvars;        /**< Number of variables. */
@@ -135,6 +135,7 @@ int check_file(int ntasks, char *filename) {
     /* Close the file. */
     if ((ret = nc_close(ncid)))
 	return ret;
+#endif
 
     /* Everything looks good! */
     return 0;

--- a/examples/c/example2.c
+++ b/examples/c/example2.c
@@ -217,7 +217,7 @@ init_logging(int my_rank, int event_num[][NUM_EVENTS])
  *
  * @return 0 if example file is correct, non-zero otherwise. */
 int check_file(int ntasks, char *filename) {
-    
+#ifdef _NETCDF
     int ncid;         /**< File ID from netCDF. */
     int ndims;        /**< Number of dimensions. */
     int nvars;        /**< Number of variables. */
@@ -274,6 +274,7 @@ int check_file(int ntasks, char *filename) {
 /* Close the file. */
     if ((ret = nc_close(ncid)))
 	return ret;
+#endif
 
 /* Everything looks good! */
     return 0;

--- a/examples/c/example2.c
+++ b/examples/c/example2.c
@@ -526,6 +526,9 @@ int main(int argc, char* argv[])
      * available ways. */
     for (int fmt = 0; fmt < NUM_NETCDF_FLAVORS; fmt++) 
     {
+        if (PIOc_iotype_available(format[fmt]) == 0)
+            continue;
+
 #ifdef HAVE_MPE
 	/* Log with MPE that we are starting CREATE. */
 	if ((ret = MPE_Log_event(event_num[START][CREATE_PNETCDF+fmt], 0, "start create")))

--- a/examples/c/examplePio.c
+++ b/examples/c/examplePio.c
@@ -186,7 +186,11 @@ struct examplePioClass* epc_init( struct examplePioClass* this )
     this->stride        = 1;
     this->numAggregator = 0;
     this->optBase       = 0;
+#ifdef _NETCDF
     this->iotype        = PIO_IOTYPE_NETCDF;
+#else /* Assume that _PNETCDF is defined. */
+    this->iotype        = PIO_IOTYPE_PNETCDF;
+#endif
     this->fileName      = "examplePio_c.nc";
     this->dimLen[0]     = LEN;
     

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -96,7 +96,9 @@ if (PIO_MICRO_TIMING)
 endif ()
 
 #===== NetCDF-C =====
-find_package (NetCDF "4.3.3" COMPONENTS C)
+if (WITH_NETCDF)
+  find_package (NetCDF "4.3.3" COMPONENTS C)
+endif ()
 if (NetCDF_C_FOUND)
   target_include_directories (pioc
     PUBLIC ${NetCDF_C_INCLUDE_DIRS})

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -685,6 +685,7 @@ int recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
                     */
                     switch (iodesc->piotype)
                     {
+#ifdef _NETCDF
                     case PIO_BYTE:
                         ierr = nc_put_vara_schar(file->fh, varids[nv], start, count, (signed char*)bufptr);
                         break;
@@ -703,6 +704,7 @@ int recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
                     case PIO_DOUBLE:
                         ierr = nc_put_vara_double(file->fh, varids[nv], start, count, (double*)bufptr);
                         break;
+#endif /* _NETCDF */
 #ifdef _NETCDF4
                     case PIO_UBYTE:
                         ierr = nc_put_vara_uchar(file->fh, varids[nv], start, count, (unsigned char*)bufptr);
@@ -1313,6 +1315,7 @@ int pio_read_darray_nc_serial(file_desc_t *file, int fndims, io_desc_t *iodesc, 
                     /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
                     switch (iodesc->piotype)
                     {
+#ifdef _NETCDF
                     case PIO_BYTE:
                         ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
                         break;
@@ -1331,6 +1334,7 @@ int pio_read_darray_nc_serial(file_desc_t *file, int fndims, io_desc_t *iodesc, 
                     case PIO_DOUBLE:
                         ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
                         break;
+#endif /* _NETCDF */
 #ifdef _NETCDF4
                     case PIO_UBYTE:
                         ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -74,20 +74,29 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
 
     LOG((1, "PIOc_open iosysid = %d path = %s mode = %x", iosysid, path, mode));
 
+    /* Set the default iotype. */
+#ifdef _NETCDF
+    iotype = PIO_IOTYPE_NETCDF;
+#else /* Assume that _PNETCDF is defined. */
+    iotype = PIO_IOTYPE_PNETCDF;
+#endif
+
     /* Figure out the iotype. */
     if (mode & NC_NETCDF4)
     {
+#ifdef _NETCDF4
         if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
             iotype = PIO_IOTYPE_NETCDF4P;
         else
             iotype = PIO_IOTYPE_NETCDF4C;
+#endif
     }
     else
     {
+#ifdef _PNETCDF
         if (mode & NC_PNETCDF || mode & NC_MPIIO)
             iotype = PIO_IOTYPE_PNETCDF;
-        else
-            iotype = PIO_IOTYPE_NETCDF;
+#endif
     }
 
     /* Open the file. If the open fails, do not retry as serial
@@ -170,20 +179,29 @@ int PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
 {
     int iotype;            /* The PIO IO type. */
 
+    /* Set the default iotype. */
+#ifdef _NETCDF
+    iotype = PIO_IOTYPE_NETCDF;
+#else /* Assume that _PNETCDF is defined. */
+    iotype = PIO_IOTYPE_PNETCDF;
+#endif
+
     /* Figure out the iotype. */
     if (cmode & NC_NETCDF4)
     {
+#ifdef _NETCDF4
         if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
             iotype = PIO_IOTYPE_NETCDF4P;
         else
             iotype = PIO_IOTYPE_NETCDF4C;
+#endif
     }
     else
     {
+#ifdef _PNETCDF
         if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
             iotype = PIO_IOTYPE_PNETCDF;
-        else
-            iotype = PIO_IOTYPE_NETCDF;
+#endif
     }
 
     return PIOc_createfile_int(iosysid, ncidp, &iotype, filename, cmode);

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -246,10 +246,12 @@ int PIOc_closefile(int ncid)
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank == 0)
                 ierr = nc_close(file->fh);
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             if ((file->mode & PIO_WRITE)){
@@ -325,7 +327,11 @@ int PIOc_deletefile(int iosysid, const char *filename)
         mpierr = MPI_Barrier(ios->io_comm);
 
         if (!mpierr && ios->io_rank == 0)
+#ifdef _NETCDF
              ierr = nc_delete(filename);
+#else /* Assume that _PNETCDF is defined. */
+             ierr = ncmpi_delete(filename, MPI_INFO_NULL);
+#endif
 
         if (!mpierr)
             mpierr = MPI_Barrier(ios->io_comm);
@@ -430,10 +436,12 @@ int PIOc_sync(int ncid)
                 break;
             case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
             case PIO_IOTYPE_NETCDF:
                 if (ios->io_rank == 0)
                     ierr = nc_sync(file->fh);
                 break;
+#endif
 #ifdef _PNETCDF
             case PIO_IOTYPE_PNETCDF:
                 flush_output_buffer(file, true, 0);

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -136,6 +136,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         {
             switch(memtype)
             {
+#ifdef _NETCDF
             case NC_CHAR:
                 ierr = nc_put_att_text(file->fh, varid, name, len, op);
                 break;
@@ -157,6 +158,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             case NC_DOUBLE:
                 ierr = nc_put_att_double(file->fh, varid, name, atttype, len, op);
                 break;
+#endif /* _NETCDF */
 #ifdef _NETCDF4
             case NC_UBYTE:
                 ierr = nc_put_att_uchar(file->fh, varid, name, atttype, len, op);
@@ -331,6 +333,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
         {
             switch(memtype)
             {
+#ifdef _NETCDF
             case NC_CHAR:
                 ierr = nc_get_att_text(file->fh, varid, name, ip);
                 break;
@@ -352,6 +355,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
             case NC_DOUBLE:
                 ierr = nc_get_att_double(file->fh, varid, name, ip);
                 break;
+#endif /* _NETCDF */
 #ifdef _NETCDF4
             case NC_UBYTE:
                 ierr = nc_get_att_uchar(file->fh, varid, name, ip);
@@ -612,6 +616,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             switch(xtype)
             {
+#ifdef _NETCDF
             case NC_BYTE:
                 ierr = nc_get_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
                                          (ptrdiff_t *)stride, buf);
@@ -640,6 +645,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 ierr = nc_get_vars_double(file->fh, varid, (size_t *)start, (size_t *)count,
                                           (ptrdiff_t *)stride, buf);
                 break;
+#endif
 #ifdef _NETCDF4
             case NC_UBYTE:
                 ierr = nc_get_vars_uchar(file->fh, varid, (size_t *)start, (size_t *)count,
@@ -1094,6 +1100,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                  file->iotype));
             switch(xtype)
             {
+#ifdef _NETCDF
             case NC_BYTE:
                 ierr = nc_put_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
                                          (ptrdiff_t *)stride, buf);
@@ -1122,6 +1129,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 ierr = nc_put_vars_double(file->fh, varid, (size_t *)start, (size_t *)count,
                                           (ptrdiff_t *)stride, buf);
                 break;
+#endif
 #ifdef _NETCDF4
             case NC_UBYTE:
                 ierr = nc_put_vars_uchar(file->fh, varid, (size_t *)start, (size_t *)count,

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -81,6 +81,7 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
                 LOG((2, "PIOc_inq returned from ncmpi_inq unlimdimid = %d", *unlimdimidp));
         }
 #endif /* _PNETCDF */
+#ifdef _NETCDF
         if (file->iotype == PIO_IOTYPE_NETCDF && file->do_io)
         {
             LOG((2, "PIOc_inq calling classic nc_inq"));
@@ -104,11 +105,14 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
             if (unlimdimidp)
                 LOG((2, "classic unlimdimid = %d", *unlimdimidp));
         }
+#ifdef _NETCDF4
         else if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             LOG((2, "PIOc_inq calling netcdf-4 nc_inq"));
             ierr = nc_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);
         }
+#endif /* _NETCDF4 */
+#endif /* _NETCDF */
 
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
@@ -248,6 +252,7 @@ int PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
     {
         if (file->iotype == PIO_IOTYPE_NETCDF && file->do_io)
         {
+#ifdef _NETCDF
             LOG((2, "netcdf"));
             int tmp_unlimdimid;
             ierr = nc_inq_unlimdim(file->fh, &tmp_unlimdimid);
@@ -257,6 +262,7 @@ int PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
                 *nunlimdimsp = tmp_unlimdimid >= 0 ? 1 : 0;
             if (unlimdimidsp)
                 *unlimdimidsp = tmp_unlimdimid;
+#endif /* _NETCDF */
         }
 #ifdef _PNETCDF
         else if (file->iotype == PIO_IOTYPE_PNETCDF)
@@ -371,8 +377,10 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
             ierr = pioc_pnetcdf_inq_type(ncid, xtype, name, sizep);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_type(file->fh, xtype, name, (size_t *)sizep);
+#endif /* _NETCDF */
         LOG((2, "PIOc_inq_type netcdf call returned %d", ierr));
     }
 
@@ -446,8 +454,10 @@ int PIOc_inq_format(int ncid, int *formatp)
             ierr = ncmpi_inq_format(file->fh, formatp);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_format(file->fh, formatp);
+#endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
@@ -520,11 +530,13 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
         }
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             LOG((2, "calling nc_inq_dim"));
             ierr = nc_inq_dim(file->fh, dimid, name, (size_t *)lenp);;
         }
+#endif /* _NETCDF */
         LOG((2, "ierr = %d", ierr));
     }
 
@@ -645,8 +657,10 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
             ierr = ncmpi_inq_dimid(file->fh, name, idp);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_dimid(file->fh, name, idp);
+#endif /* _NETCDF */
     }
     LOG((3, "nc_inq_dimid call complete ierr = %d", ierr));
 
@@ -766,6 +780,7 @@ int PIOc_inq_var(int ncid, int varid, char *name, int namelen, nc_type *xtypep, 
         }
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             ierr = nc_inq_varndims(file->fh, varid, &ndims);
@@ -810,6 +825,7 @@ int PIOc_inq_var(int ncid, int varid, char *name, int namelen, nc_type *xtypep, 
                 }
             }
         }
+#endif /* _NETCDF */
         if (ndimsp)
             LOG((2, "PIOc_inq_var ndims = %d ierr = %d", *ndimsp, ierr));
     }
@@ -1042,8 +1058,10 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
             ierr = ncmpi_inq_varid(file->fh, name, varidp);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_varid(file->fh, name, varidp);
+#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1160,8 +1178,10 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
             ierr = ncmpi_inq_att(file->fh, varid, name, xtypep, lenp);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);
+#endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
@@ -1269,8 +1289,10 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
             ierr = ncmpi_inq_attname(file->fh, varid, attnum, name);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_attname(file->fh, varid, attnum, name);
+#endif /* _NETCDF */
         LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
     }
 
@@ -1351,8 +1373,10 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
             ierr = ncmpi_inq_attid(file->fh, varid, name, idp);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_attid(file->fh, varid, name, idp);
+#endif /* _NETCDF */
         LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
     }
 
@@ -1425,8 +1449,10 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
             ierr = ncmpi_rename_dim(file->fh, dimid, name);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_rename_dim(file->fh, dimid, name);
+#endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
@@ -1495,8 +1521,10 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
             ierr = ncmpi_rename_var(file->fh, varid, name);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_rename_var(file->fh, varid, name);
+#endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
@@ -1570,8 +1598,10 @@ int PIOc_rename_att(int ncid, int varid, const char *name,
             ierr = ncmpi_rename_att(file->fh, varid, name, newname);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_rename_att(file->fh, varid, name, newname);
+#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1640,8 +1670,10 @@ int PIOc_del_att(int ncid, int varid, const char *name)
             ierr = ncmpi_del_att(file->fh, varid, name);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_del_att(file->fh, varid, name);
+#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1708,8 +1740,10 @@ int PIOc_set_fill(int ncid, int fillmode, int *old_modep)
         }
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_set_fill(file->fh, fillmode, old_modep);
+#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1829,9 +1863,10 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
             ierr = ncmpi_def_dim(file->fh, name, len, idp);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_def_dim(file->fh, name, (size_t)len, idp);
-
+#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1952,8 +1987,10 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
             ierr = ncmpi_def_var(file->fh, name, xtype, ndims, dimidsp, varidp);
 #endif /* _PNETCDF */
 
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_def_var(file->fh, name, xtype, ndims, dimidsp, varidp);
+#endif /* _NETCDF */
 #ifdef _NETCDF4
         /* For netCDF-4 serial files, turn on compression for this variable. */
         if (!ierr && file->iotype == PIO_IOTYPE_NETCDF4C)
@@ -2140,9 +2177,11 @@ int PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_value
         }
         else if (file->iotype == PIO_IOTYPE_NETCDF)
         {
+#ifdef _NETCDF
             LOG((2, "defining fill value attribute for netCDF classic file"));
             if (file->do_io)            
                 ierr = nc_put_att(file->fh, varid, _FillValue, xtype, 1, fill_valuep);
+#endif /* _NETCDF */
         }
         else
         {
@@ -2247,6 +2286,7 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
         }
         else if (file->iotype == PIO_IOTYPE_NETCDF && file->do_io)
         {
+#ifdef _NETCDF
             /* Get the file-level fill mode. */
             if (no_fill)
             {
@@ -2292,6 +2332,7 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
                     ierr = PIO_NOERR;
                 }
             }
+#endif /* _NETCDF */
         }
         else
         {

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -41,11 +41,13 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -110,11 +112,13 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -179,11 +183,13 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -249,11 +255,13 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -320,11 +328,13 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -391,11 +401,13 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -461,11 +473,13 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -532,11 +546,13 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -602,11 +618,13 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -674,11 +692,13 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -745,11 +765,13 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -815,11 +837,13 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -884,11 +908,13 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank==0){
                 ierr = nc_put_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -952,12 +978,14 @@ int PIOc_get_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1021,12 +1049,14 @@ int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1090,12 +1120,14 @@ int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const P
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1159,12 +1191,14 @@ int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1228,12 +1262,14 @@ int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1297,12 +1333,14 @@ int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1361,12 +1399,14 @@ int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1430,12 +1470,14 @@ int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1499,12 +1541,14 @@ int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1568,12 +1612,14 @@ int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1637,12 +1683,14 @@ int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1706,12 +1754,14 @@ int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1775,12 +1825,14 @@ int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             bcast = true;
             if (ios->iomaster == MPI_ROOT){
                 ierr = nc_get_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1205,12 +1205,13 @@ int PIOc_iotype_available(int iotype)
     case PIO_IOTYPE_NETCDF4C:
         return 1;
 #endif
+#ifdef _NETCDF
     case PIO_IOTYPE_NETCDF:
         return 1;
+#endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
         return 1;
-        break;
 #endif
     default:
         return 0;

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1839,6 +1839,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         case PIO_IOTYPE_NETCDF4C:
             file->mode = file->mode | NC_NETCDF4;
 #endif
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (!ios->io_rank)
             {
@@ -1846,6 +1847,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
                 ierr = nc_create(filename, file->mode, &file->fh);
             }
             break;
+#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             LOG((2, "Calling ncmpi_create mode = %d", file->mode));
@@ -2079,10 +2081,12 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
             break;
 #endif /* _NETCDF4 */
 
+#ifdef _NETCDF
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank == 0)
                 ierr = nc_open(filename, file->mode, &file->fh);
             break;
+#endif /* _NETCDF */
 
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
@@ -2108,6 +2112,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
            with just plain old basic NetCDF. */
         if (retry)
         {
+#ifdef _NETCDF
             LOG((2, "retry error code ierr = %d io_rank %d", ierr, ios->io_rank));
             if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
             {
@@ -2134,6 +2139,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
             }
             LOG((2, "retry nc_open(%s) : fd = %d, iotype = %d, do_io = %d, ierr = %d",
                  filename, file->fh, file->iotype, file->do_io, ierr));
+#endif /* _NETCDF */
         }
     }
 
@@ -2376,6 +2382,7 @@ int pioc_change_def(int ncid, int is_enddef)
                 ierr = ncmpi_redef(file->fh);
         }
 #endif /* _PNETCDF */
+#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             if (is_enddef)
@@ -2386,6 +2393,7 @@ int pioc_change_def(int ncid, int is_enddef)
             else
                 ierr = nc_redef(file->fh);
         }
+#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2418,9 +2418,11 @@ int iotype_is_valid(int iotype)
     /* Assume it's not valid. */
     int ret = 0;
 
-    /* All builds include netCDF. */
+    /* Some builds include netCDF. */
+#ifdef _NETCDF
     if (iotype == PIO_IOTYPE_NETCDF)
         ret++;
+#endif /* _NETCDF */
 
     /* Some builds include netCDF-4. */
 #ifdef _NETCDF4

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -206,7 +206,9 @@ if (PIO_ENABLE_TIMING)
 endif ()
 
 #===== NetCDF-Fortran =====
-find_package (NetCDF "4.3.3" COMPONENTS Fortran)
+if (WITH_NETCDF)
+  find_package (NetCDF "4.3.3" COMPONENTS Fortran)
+endif ()
 if (NetCDF_Fortran_FOUND)
   target_include_directories (piof
     PUBLIC ${NetCDF_Fortran_INCLUDE_DIRS})

--- a/tests/cunit/test_darray_async.c
+++ b/tests/cunit/test_darray_async.c
@@ -390,7 +390,11 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
             ERR(ret);
 
         /* Check the file for correctness. */
+#ifdef _NETCDF
         if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_NETCDF, my_rank, piotype)))
+#else /* Assume that _PNETCDF is defined. */
+        if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_PNETCDF, my_rank, piotype)))
+#endif
             ERR(ret);
 
     } /* next iotype */

--- a/tests/cunit/test_darray_async_many.c
+++ b/tests/cunit/test_darray_async_many.c
@@ -491,8 +491,13 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
             ERR(ret);
 
         /* Check the file for correctness. */
+#ifdef _NETCDF
         if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_NETCDF, my_rank,
                                      rec_varid, norec_varid, num_types, varid_4d)))
+#else /* Assume that _PNETCDF is defined. */
+        if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_PNETCDF, my_rank,
+                                     rec_varid, norec_varid, num_types, varid_4d)))
+#endif
             ERR(ret);
 
     } /* next iotype */

--- a/tests/cunit/test_darray_async_simple.c
+++ b/tests/cunit/test_darray_async_simple.c
@@ -128,7 +128,11 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
             ERR(ret);
 
         /* Check the file for correctness. */
+#ifdef _NETCDF
         if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_NETCDF, my_rank)))
+#else /* Assume that _PNETCDF is defined. */
+        if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_PNETCDF, my_rank)))
+#endif
             ERR(ret);
 
     } /* next iotype */

--- a/tests/cunit/test_decomp_uneven.c
+++ b/tests/cunit/test_decomp_uneven.c
@@ -145,7 +145,11 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
 
         /* Open the decomposition file with netCDF. */
         int ncid_in;
+#ifdef _NETCDF
         int iotype = PIO_IOTYPE_NETCDF;
+#else /* Assume that _PNETCDF is defined. */
+        int iotype = PIO_IOTYPE_PNETCDF;
+#endif
         if ((ret = PIOc_openfile(iosysid, &ncid_in, &iotype, filename, NC_NOWRITE)))
             return ret;
 

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -498,9 +498,14 @@ int test_iotypes(int my_rank)
     if (PIOc_iotype_available(1000))
         return ERR_WRONG;
 
-    /* NetCDF is always present. */
+    /* NetCDF may or may not be present. */
+#ifdef _NETCDF
     if (!PIOc_iotype_available(PIO_IOTYPE_NETCDF))
         return ERR_WRONG;
+#else
+    if (PIOc_iotype_available(PIO_IOTYPE_NETCDF))
+        return ERR_WRONG;
+#endif /* _NETCDF */
 
     /* Pnetcdf may or may not be present. */
 #ifdef _PNETCDF
@@ -1644,7 +1649,11 @@ int test_decomp_internal(int my_test_size, int my_rank, int iosysid, int dim_len
 
     /* This will be our file name for writing out decompositions. */
     sprintf(filename, "decomp_%s_rank_%d_async_%d.txt", TEST_NAME, my_rank, async);
+#ifdef _NETCDF
     sprintf(nc_filename, "nc_decomp_internal_%s_rank_%d_async_%d.nc", TEST_NAME, my_rank, async);
+#else /* Assume that _PNETCDF is defined. */
+    sprintf(nc_filename, "ncmpi_decomp_internal_%s_async_%d.nc", TEST_NAME, async);
+#endif
 
     /* Decompose the data over the tasks. */
     if ((ret = create_decomposition(my_test_size, my_rank, iosysid, dim_len, &ioid)))
@@ -1831,7 +1840,11 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
     int ret;
 
     /* This will be our file name for writing out decompositions. */
+#ifdef _NETCDF
     sprintf(nc_filename, "nc_decomp_%s_rank_%d_async_%d.nc", TEST_NAME, my_rank, async);
+#else /* Assume that _PNETCDF is defined. */
+    sprintf(nc_filename, "ncmpi_decomp_%s_async_%d.nc", TEST_NAME, async);
+#endif
 
     /* Decompose the data over the tasks. */
     if ((ret = create_decomposition(my_test_size, my_rank, iosysid, dim_len, &ioid)))
@@ -1977,7 +1990,11 @@ int test_decomp_public_2(int my_test_size, int my_rank, int iosysid, int dim_len
     int ret;
 
     /* This will be our file name for writing out decompositions. */
+#ifdef _NETCDF
     sprintf(nc_filename, "nc_decomp_%s_rank_%d_async_%d.nc", TEST_NAME, my_rank, async);
+#else /* Assume that _PNETCDF is defined. */
+    sprintf(nc_filename, "ncmpi_decomp_%s_async_%d.nc", TEST_NAME, async);
+#endif
 
     /* Decompose the data over the tasks. */
     if ((ret = create_decomposition(my_test_size, my_rank, iosysid, dim_len, &ioid)))

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -534,6 +534,7 @@ int test_iotypes(int my_rank)
  */
 int check_strerror_netcdf(int my_rank)
 {
+#ifdef _NETCDF
 #define NUM_NETCDF_TRIES 5
     int errcode[NUM_NETCDF_TRIES] = {PIO_EBADID, NC4_LAST_ERROR - 1, 0, 1, -600};
     const char *expected[NUM_NETCDF_TRIES] = {"NetCDF: Not a valid ID",
@@ -566,6 +567,7 @@ int check_strerror_netcdf(int my_rank)
 
     if (!my_rank)
         printf("check_strerror_netcdf SUCCEEDED!\n");
+#endif /* _NETCDF */
 
     return PIO_NOERR;
 }
@@ -634,7 +636,11 @@ int check_strerror_pio(int my_rank)
     const char *expected[NUM_PIO_TRIES] = {"NetCDF: Not a valid ID",
                                            "NetCDF: Attempting netcdf-3 operation on netcdf-4 file",
                                            "Unknown Error: Unrecognized error code", "No error",
+#ifdef _NETCDF
                                            nc_strerror(1), "Bad IO type"};
+#else /* Assume that _PNETCDF is defined. */
+                                           ncmpi_strerror(1), "Bad IO type"};
+#endif
     int ret;
 
     if ((ret = check_error_strings(my_rank, NUM_PIO_TRIES, errcode, expected)))
@@ -1453,6 +1459,7 @@ int test_scalar(int iosysid, int num_flavors, int *flavor, int my_rank, int asyn
 
     /* Use netCDF classic to create a file with a scalar var, then set
      * and read the value. */
+#ifdef _NETCDF
     if (my_rank == 0)
     {
         char test_file[] = "netcdf_test.nc";
@@ -1482,6 +1489,7 @@ int test_scalar(int iosysid, int num_flavors, int *flavor, int my_rank, int asyn
         if ((ret = nc_close(ncid)))
             return ret;
     }
+#endif /* _NETCDF */
 
     /* Use pnetCDF to create a file with a scalar var, then set and
      * read the value. */

--- a/tests/cunit/test_pioc_unlim.c
+++ b/tests/cunit/test_pioc_unlim.c
@@ -132,6 +132,7 @@ int create_test_file(int iosysid, int ioid, int iotype, int my_rank, int *ncid, 
 int run_multiple_unlim_test(int iosysid, int ioid, int iotype, int my_rank,
                             MPI_Comm test_comm)
 {
+#ifdef _NETCDF4
 #define UDIM1_NAME "unlimited1"
 #define UDIM2_NAME "unlimited2"
 #define NUM_UNLIM_DIMS 2
@@ -231,6 +232,7 @@ int run_multiple_unlim_test(int iosysid, int ioid, int iotype, int my_rank,
     if (PIOc_openfile2(iosysid, &ncid, &iotype, NETCDF4_UNLIM_FILE_NAME,
                        0) != PIO_EINVAL)
         ERR(ERR_WRONG);
+#endif /* _NETCDF4 */
 
     return PIO_NOERR;
 }


### PR DESCRIPTION
Users using PnetCDF with PIO should not have to build PIO
with NetCDF.

There are instances in the existing code where it is assumed
that NetCDF is always available. For PIO configured without
NetCDF, that assumption no longer holds and we need to fix
all build errors and failed tests.

Also add a configuration option to turn on/off the use of NetCDF
in PIO (default = ON).

Fixes #21