### PR TITLE
Support newer versions of PnetCDF

### DIFF
--- a/examples/c/darray_async.c
+++ b/examples/c/darray_async.c
@@ -116,7 +116,7 @@ int resultlen;
 /*     nc_type xtype;    /\* NetCDF data type of this variable. *\/ */
 /*     int ret;          /\* Return code for function calls. *\/ */
 /*     int dimids[NDIM3]; /\* Dimension ids for this variable. *\/ */
-/*     char var_name[NC_MAX_NAME];   /\* Name of the variable. *\/ */
+/*     char var_name[PIO_MAX_NAME];   /\* Name of the variable. *\/ */
 /*     /\* size_t start[NDIM3];           /\\* Zero-based index to start read. *\\/ *\/ */
 /*     /\* size_t count[NDIM3];           /\\* Number of elements to read. *\\/ *\/ */
 /*     /\* int buffer[DIM_LEN_X];          /\\* Buffer to read in data. *\\/ *\/ */
@@ -136,7 +136,7 @@ int resultlen;
 /*         return ERR_BAD; */
 /*     for (int d = 0; d < NDIM3; d++) */
 /*     { */
-/*         char my_dim_name[NC_MAX_NAME]; */
+/*         char my_dim_name[PIO_MAX_NAME]; */
 /*         PIO_Offset dimlen;  */
         
 /*         if ((ret = PIOc_inq_dim(ncid, d, my_dim_name, &dimlen))) */
@@ -221,7 +221,7 @@ data:
 	/* int ncid;     /\* The ncid of the netCDF file. *\/ */
 	/* int dimid[NDIM3];    /\* The dimension ID. *\/ */
 	/* int varid;    /\* The ID of the netCDF varable. *\/ */
-        /* char filename[NC_MAX_NAME + 1]; /\* Test filename. *\/ */
+        /* char filename[PIO_MAX_NAME + 1]; /\* Test filename. *\/ */
         /* int num_flavors = 0;            /\* Number of iotypes available in this build. *\/ */
 	/* int format[NUM_NETCDF_FLAVORS]; /\* Different output flavors. *\/ */
 	int ret;                        /* Return value. */

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -104,7 +104,7 @@ int check_file(int iosysid, int ntasks, char *filename, int iotype,
     nc_type xtype;    /* NetCDF data type of this variable. */
     int ret;          /* Return code for function calls. */
     int dimids[NDIM3]; /* Dimension ids for this variable. */
-    char var_name[NC_MAX_NAME];   /* Name of the variable. */
+    char var_name[PIO_MAX_NAME];   /* Name of the variable. */
     /* size_t start[NDIM3];           /\* Zero-based index to start read. *\/ */
     /* size_t count[NDIM3];           /\* Number of elements to read. *\/ */
     /* int buffer[DIM_LEN_X];          /\* Buffer to read in data. *\/ */
@@ -124,7 +124,7 @@ int check_file(int iosysid, int ntasks, char *filename, int iotype,
         return ERR_BAD;
     for (int d = 0; d < NDIM3; d++)
     {
-        char my_dim_name[NC_MAX_NAME];
+        char my_dim_name[PIO_MAX_NAME];
         PIO_Offset dimlen; 
         
         if ((ret = PIOc_inq_dim(ncid, d, my_dim_name, &dimlen)))
@@ -134,7 +134,7 @@ int check_file(int iosysid, int ntasks, char *filename, int iotype,
     }
 
     /* Check the variable. */
-    if ((ret = PIOc_inq_var(ncid, 0, var_name, NC_MAX_NAME, &xtype, &ndims, dimids, &natts)))
+    if ((ret = PIOc_inq_var(ncid, 0, var_name, PIO_MAX_NAME, &xtype, &ndims, dimids, &natts)))
         return ret;
     if (xtype != NC_INT || ndims != NDIM3 || dimids[0] != 0 || dimids[1] != 1 ||
             dimids[2] != 2 || natts != 0)
@@ -213,7 +213,7 @@ data:
 	int dimid[NDIM3];    /* The dimension ID. */
 	int varid;    /* The ID of the netCDF varable. */
 	int ioid;     /* The I/O description ID. */
-        char filename[NC_MAX_NAME + 1]; /* Test filename. */
+        char filename[PIO_MAX_NAME + 1]; /* Test filename. */
         int num_flavors = 0;            /* Number of iotypes available in this build. */
 	int format[NUM_NETCDF_FLAVORS]; /* Different output flavors. */
 	int ret;                        /* Return value. */

--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -92,8 +92,8 @@ int check_file(int ntasks, char *filename) {
     nc_type xtype;    /**< NetCDF data type of this variable. */
     int ret;          /**< Return code for function calls. */
     int dimids[NDIM]; /**< Dimension ids for this variable. */
-    char dim_name[NC_MAX_NAME];   /**< Name of the dimension. */
-    char var_name[NC_MAX_NAME];   /**< Name of the variable. */
+    char dim_name[PIO_MAX_NAME];   /**< Name of the dimension. */
+    char var_name[PIO_MAX_NAME];   /**< Name of the variable. */
     size_t start[NDIM];           /**< Zero-based index to start read. */
     size_t count[NDIM];           /**< Number of elements to read. */
     int buffer[DIM_LEN];          /**< Buffer to read in data. */
@@ -255,7 +255,7 @@ int check_file(int ntasks, char *filename) {
 	PIO_Offset *compdof;
 
         /** Test filename. */
-        char filename[NC_MAX_NAME + 1];
+        char filename[PIO_MAX_NAME + 1];
 
         /** The number of netCDF flavors available in this build. */
         int num_flavors = 0;

--- a/examples/c/example2.c
+++ b/examples/c/example2.c
@@ -92,7 +92,7 @@ char err_buffer[MPI_MAX_ERROR_STRING];
 int resultlen;
 
 /** The dimension names. */
-char dim_name[NDIM][NC_MAX_NAME + 1] = {"timestep", "x", "y"};
+char dim_name[NDIM][PIO_MAX_NAME + 1] = {"timestep", "x", "y"};
 
 /** Length of the dimensions in the sample data. */
 int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
@@ -228,8 +228,8 @@ int check_file(int ntasks, char *filename) {
     nc_type xtype;    /**< NetCDF data type of this variable. */
     int ret;          /**< Return code for function calls. */
     int dimids[NDIM]; /**< Dimension ids for this variable. */
-    char my_dim_name[NC_MAX_NAME + 1]; /**< Name of the dimension. */
-    char var_name[NC_MAX_NAME + 1];    /**< Name of the variable. */
+    char my_dim_name[PIO_MAX_NAME + 1]; /**< Name of the dimension. */
+    char var_name[PIO_MAX_NAME + 1];    /**< Name of the variable. */
     size_t start[NDIM];                /**< Zero-based index to start read. */
     size_t count[NDIM];                /**< Number of elements to read. */
     int buffer[X_DIM_LEN];             /**< Buffer to read in data. */
@@ -360,7 +360,7 @@ int main(int argc, char* argv[])
      * (serial4 and parallel4) will be in netCDF-4/HDF5
      * format. All four can be read by the netCDF library, and all
      * will contain the same contents. */
-    char filename[NUM_NETCDF_FLAVORS][NC_MAX_NAME + 1] = {"example2_pnetcdf.nc",
+    char filename[NUM_NETCDF_FLAVORS][PIO_MAX_NAME + 1] = {"example2_pnetcdf.nc",
 							  "example2_classic.nc",
 							  "example2_serial4.nc",
 							  "example2_parallel4.nc"};

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -38,10 +38,28 @@
 #define PIO_Offset MPI_Offset
 
 /** The maximum number of variables allowed in a netCDF file. */
+#define PIO_MAX_VARS_UB 8192
+#if NC_MAX_VARS > PIO_MAX_VARS_UB
+#define PIO_MAX_VARS PIO_MAX_VARS_UB
+#else
 #define PIO_MAX_VARS NC_MAX_VARS
+#endif
 
 /** The maximum number of dimensions allowed in a netCDF file. */
+#define PIO_MAX_DIMS_UB 1024
+#if NC_MAX_DIMS > PIO_MAX_DIMS_UB
+#define PIO_MAX_DIMS PIO_MAX_DIMS_UB
+#else
 #define PIO_MAX_DIMS NC_MAX_DIMS
+#endif
+
+/** The maximum number of attributes allowed in a netCDF file. */
+#define PIO_MAX_ATTRS_UB 8192
+#if NC_MAX_ATTRS > PIO_MAX_ATTRS_UB
+#define PIO_MAX_ATTRS PIO_MAX_ATTRS_UB
+#else
+#define PIO_MAX_ATTRS NC_MAX_ATTRS
+#endif
 
 /** Pass this to PIOc_set_iosystem_error_handling() as the iosysid in
  * order to set default error handling. */
@@ -126,8 +144,18 @@
 #define PIO_NOCLOBBER NC_NOCLOBBER
 #define PIO_FILL NC_FILL
 #define PIO_NOFILL NC_NOFILL
+#define PIO_MAX_NAME_UB 1024
+#if NC_MAX_NAME > PIO_MAX_NAME_UB
+#define PIO_MAX_NAME PIO_MAX_NAME_UB
+#else
 #define PIO_MAX_NAME NC_MAX_NAME
+#endif
+#define PIO_MAX_VAR_DIMS_UB 1024
+#if NC_MAX_VAR_DIMS > PIO_MAX_VAR_DIMS_UB
+#define PIO_MAX_VAR_DIMS PIO_MAX_VAR_DIMS_UB
+#else
 #define PIO_MAX_VAR_DIMS NC_MAX_VAR_DIMS
+#endif
 #define PIO_64BIT_OFFSET NC_64BIT_OFFSET
 
 /** NC_64BIT_DATA This is a problem - need to define directly instead

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -48,7 +48,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     ios = file->iosystem;
 
     /* User must provide some valid parameters. */
-    if (!name || !op || strlen(name) > NC_MAX_NAME || len < 0)
+    if (!name || !op || strlen(name) > PIO_MAX_NAME || len < 0)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_put_att_tc ncid = %d varid = %d name = %s atttype = %d len = %d memtype = %d",
@@ -236,7 +236,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
     ios = file->iosystem;
 
     /* User must provide a name and destination pointer. */
-    if (!name || !ip || strlen(name) > NC_MAX_NAME)
+    if (!name || !ip || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_get_att_tc ncid %d varid %d name %s memtype %d",

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -1072,7 +1072,7 @@ int inq_type_handler(iosystem_desc_t *ios)
     int ncid;
     int xtype;
     char name_present, size_present;
-    char *namep = NULL, name[NC_MAX_NAME + 1];
+    char *namep = NULL, name[PIO_MAX_NAME + 1];
     PIO_Offset *sizep = NULL, size;
     int mpierr;
     int ret;
@@ -1387,7 +1387,7 @@ int inq_dim_handler(iosystem_desc_t *ios, int msg)
     char name_present, len_present;
     char *dimnamep = NULL;
     PIO_Offset *dimlenp = NULL;
-    char dimname[NC_MAX_NAME + 1];
+    char dimname[PIO_MAX_NAME + 1];
     PIO_Offset dimlen;
 
     int mpierr;
@@ -1527,7 +1527,7 @@ int inq_attname_handler(iosystem_desc_t *ios)
     int ncid;
     int varid;
     int attnum;
-    char name[NC_MAX_NAME + 1], *namep = NULL;
+    char name[PIO_MAX_NAME + 1], *namep = NULL;
     char name_present;
     int mpierr;
     int ret;
@@ -1749,7 +1749,7 @@ int put_vars_handler(iosystem_desc_t *ios)
     LOG((1, "put_vars_handler"));
     assert(ios);
 
-    PIO_Offset start[NC_MAX_DIMS], count[NC_MAX_DIMS], stride[NC_MAX_DIMS];
+    PIO_Offset start[PIO_MAX_DIMS], count[PIO_MAX_DIMS], stride[PIO_MAX_DIMS];
     int nstart=0, ncount=0, nstride=0;
 
     /* Get the parameters for this function that the the comp master
@@ -1853,9 +1853,9 @@ int get_vars_handler(iosystem_desc_t *ios)
     PIO_Offset typelen; /** Length (in bytes) of this type. */
     nc_type xtype; /** 
                     * Type of the data being written. */
-    PIO_Offset start[NC_MAX_DIMS];
-    PIO_Offset count[NC_MAX_DIMS];
-    PIO_Offset stride[NC_MAX_DIMS];
+    PIO_Offset start[PIO_MAX_DIMS];
+    PIO_Offset count[PIO_MAX_DIMS];
+    PIO_Offset stride[PIO_MAX_DIMS];
     char start_present;
     char count_present;
     char stride_present;
@@ -1969,10 +1969,10 @@ int inq_var_handler(iosystem_desc_t *ios)
     int varid;
     int mpierr;
     char name_present, xtype_present, ndims_present, dimids_present, natts_present;
-    char name[NC_MAX_NAME + 1], *namep = NULL;
+    char name[PIO_MAX_NAME + 1], *namep = NULL;
     nc_type xtype, *xtypep = NULL;
     int *ndimsp = NULL, *dimidsp = NULL, *nattsp = NULL;
-    int ndims, dimids[NC_MAX_DIMS], natts;
+    int ndims, dimids[PIO_MAX_DIMS], natts;
     int ret;
 
     LOG((1, "inq_var_handler"));
@@ -2006,7 +2006,7 @@ int inq_var_handler(iosystem_desc_t *ios)
         nattsp = &natts;
 
     /* Call the inq function to get the values. */
-    if ((ret = PIOc_inq_var(ncid, varid, namep, NC_MAX_NAME + 1, xtypep, ndimsp, dimidsp, nattsp)))
+    if ((ret = PIOc_inq_var(ncid, varid, namep, PIO_MAX_NAME + 1, xtypep, ndimsp, dimidsp, nattsp)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     if (ndims_present)
@@ -2028,7 +2028,7 @@ int inq_var_chunking_handler(iosystem_desc_t *ios)
     int varid;
     char storage_present, chunksizes_present;
     int storage, *storagep = NULL;
-    PIO_Offset chunksizes[NC_MAX_DIMS], *chunksizesp = NULL;
+    PIO_Offset chunksizes[PIO_MAX_DIMS], *chunksizesp = NULL;
     int mpierr;
     int ret;
 
@@ -2416,7 +2416,7 @@ int def_var_handler(iosystem_desc_t *ios)
     nc_type xtype;
     int ndims;
     int dimids_sz;
-    int dimids[NC_MAX_DIMS];
+    int dimids[PIO_MAX_DIMS];
 
     LOG((1, "def_var_handler comproot = %d", ios->comproot));
     assert(ios);
@@ -2459,7 +2459,7 @@ int def_var_chunking_handler(iosystem_desc_t *ios)
     int storage;
     char chunksizes_present;
     int chunksizes_sz = 0;
-    PIO_Offset chunksizes[NC_MAX_DIMS], *chunksizesp = NULL;
+    PIO_Offset chunksizes[PIO_MAX_DIMS], *chunksizesp = NULL;
     int mpierr;
     int ret;
 
@@ -2964,10 +2964,10 @@ int initdecomp_dof_handler(iosystem_desc_t *ios)
 
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
-    int dims[NC_MAX_DIMS];
+    int dims[PIO_MAX_DIMS];
     int niostart = 0, niocount = 0;
-    PIO_Offset iostart[NC_MAX_DIMS];
-    PIO_Offset iocount[NC_MAX_DIMS];
+    PIO_Offset iostart[PIO_MAX_DIMS];
+    PIO_Offset iocount[PIO_MAX_DIMS];
 
     PIO_RECV_ASYNC_MSG(ios, PIO_MSG_INITDECOMP_DOF, &ret,
         &iosysid, &pio_type, &ndims, dims, &maplen, &compmap,

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -628,8 +628,8 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
     ios = file->iosystem;
     LOG((2, "iosysid = %d", ios->iosysid));
 
-    /* User must provide name shorter than NC_MAX_NAME +1. */
-    if (!name || strlen(name) > NC_MAX_NAME)
+    /* User must provide name shorter than PIO_MAX_NAME +1. */
+    if (!name || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_inq_dimid ncid = %d name = %s", ncid, name));
@@ -1033,7 +1033,7 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
     ios = file->iosystem;
 
     /* Caller must provide name. */
-    if (!name || strlen(name) > NC_MAX_NAME)
+    if (!name || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_inq_varid ncid = %d name = %s", ncid, name));
@@ -1150,8 +1150,8 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
-    /* User must provide name shorter than NC_MAX_NAME +1. */
-    if (!name || strlen(name) > NC_MAX_NAME)
+    /* User must provide name shorter than PIO_MAX_NAME +1. */
+    if (!name || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_inq_att ncid = %d varid = %d", ncid, varid));
@@ -1344,8 +1344,8 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
-    /* User must provide name shorter than NC_MAX_NAME +1. */
-    if (!name || strlen(name) > NC_MAX_NAME)
+    /* User must provide name shorter than PIO_MAX_NAME +1. */
+    if (!name || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_inq_attid ncid = %d varid = %d name = %s", ncid, varid, name));
@@ -1420,8 +1420,8 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
-    /* User must provide name shorter than NC_MAX_NAME +1. */
-    if (!name || strlen(name) > NC_MAX_NAME)
+    /* User must provide name shorter than PIO_MAX_NAME +1. */
+    if (!name || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_rename_dim ncid = %d dimid = %d name = %s", ncid, dimid, name));
@@ -1492,8 +1492,8 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
-    /* User must provide name shorter than NC_MAX_NAME +1. */
-    if (!name || strlen(name) > NC_MAX_NAME)
+    /* User must provide name shorter than PIO_MAX_NAME +1. */
+    if (!name || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_rename_var ncid = %d varid = %d name = %s", ncid, varid, name));
@@ -1567,8 +1567,8 @@ int PIOc_rename_att(int ncid, int varid, const char *name,
     ios = file->iosystem;
 
     /* User must provide names of correct length. */
-    if (!name || strlen(name) > NC_MAX_NAME ||
-        !newname || strlen(newname) > NC_MAX_NAME)
+    if (!name || strlen(name) > PIO_MAX_NAME ||
+        !newname || strlen(newname) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_rename_att ncid = %d varid = %d name = %s newname = %s",
@@ -1642,8 +1642,8 @@ int PIOc_del_att(int ncid, int varid, const char *name)
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
-    /* User must provide name shorter than NC_MAX_NAME +1. */
-    if (!name || strlen(name) > NC_MAX_NAME)
+    /* User must provide name shorter than PIO_MAX_NAME +1. */
+    if (!name || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_del_att ncid = %d varid = %d name = %s", ncid, varid, name));
@@ -1830,8 +1830,8 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
-    /* User must provide name shorter than NC_MAX_NAME +1. */
-    if (!name || strlen(name) > NC_MAX_NAME)
+    /* User must provide name shorter than PIO_MAX_NAME +1. */
+    if (!name || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     if(!idp)
@@ -1931,7 +1931,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     ios = file->iosystem;
 
     /* User must provide name and storage for varid. */
-    if (!name || !varidp || strlen(name) > NC_MAX_NAME)
+    if (!name || !varidp || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_def_var ncid = %d name = %s xtype = %d ndims = %d", ncid, name,
@@ -2390,7 +2390,7 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
     ios = file->iosystem;
 
     /* User must provide a name and destination pointer. */
-    if (!name || !ip || strlen(name) > NC_MAX_NAME)
+    if (!name || !ip || strlen(name) > PIO_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_get_att ncid %d varid %d name %s", ncid, varid, name));

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -454,7 +454,7 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, in
     }
 
 #if PIO_SAVE_DECOMPS
-    char filename[NC_MAX_NAME];
+    char filename[PIO_MAX_NAME];
     if (ios->num_comptasks < 100)
         sprintf(filename, "piodecomp%2.2dtasks%2.2dio%2.2ddims%2.2d.dat", ios->num_comptasks, ios->num_iotasks, ndims, counter);
     else if (ios->num_comptasks < 10000)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -64,11 +64,11 @@ int PIOc_strerror(int pioerr, char *errmsg)
         strcpy(errmsg, "No error");
 #if defined(_NETCDF)
     else if (pioerr <= NC2_ERR && pioerr >= NC4_LAST_ERROR)     /* NetCDF error? */
-        strncpy(errmsg, nc_strerror(pioerr), NC_MAX_NAME);
+        strncpy(errmsg, nc_strerror(pioerr), PIO_MAX_NAME);
 #endif /* endif defined(_NETCDF) */
 #if defined(_PNETCDF)
     else if (pioerr > PIO_FIRST_ERROR_CODE)     /* pNetCDF error? */
-        strncpy(errmsg, ncmpi_strerror(pioerr), NC_MAX_NAME);
+        strncpy(errmsg, ncmpi_strerror(pioerr), PIO_MAX_NAME);
 #endif /* defined( _PNETCDF) */
     else
         /* Handle PIO errors. */
@@ -127,7 +127,7 @@ int PIOc_set_log_level(int level)
 void pio_init_logging(void)
 {
 #if PIO_ENABLE_LOGGING
-    char log_filename[NC_MAX_NAME];
+    char log_filename[PIO_MAX_NAME];
 
     if (!LOG_FILE)
     {
@@ -993,9 +993,9 @@ int PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset 
  * @param cmode for PIOc_create(). Will be bitwise or'd with NC_WRITE.
  * @param ioid the ID of the IO description.
  * @param title optial title attribute for the file. Must be less than
- * NC_MAX_NAME + 1 if provided. Ignored if NULL.
+ * PIO_MAX_NAME + 1 if provided. Ignored if NULL.
  * @param history optial history attribute for the file. Must be less
- * than NC_MAX_NAME + 1 if provided. Ignored if NULL.
+ * than PIO_MAX_NAME + 1 if provided. Ignored if NULL.
  * @param fortran_order set to non-zero if fortran array ordering is
  * used, or to zero if C array ordering is used.
  * @returns 0 for success, error code otherwise.
@@ -1090,10 +1090,10 @@ int PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
  * @param comm an MPI communicator.
  * @param pio_type the PIO type to be used as the type for the data.
  * @param title pointer that will get optial title attribute for the
- * file. Will be less than NC_MAX_NAME + 1 if provided. Ignored if
+ * file. Will be less than PIO_MAX_NAME + 1 if provided. Ignored if
  * NULL.
  * @param history pointer that will get optial history attribute for
- * the file. Will be less than NC_MAX_NAME + 1 if provided. Ignored if
+ * the file. Will be less than PIO_MAX_NAME + 1 if provided. Ignored if
  * NULL.
  * @param fortran_order pointer that gets set to 1 if fortran array
  * ordering is used, or to zero if C array ordering is used.
@@ -1273,8 +1273,8 @@ int pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmo
     for (int b = 0; b < bt_size; b++)
         if (strlen(bt_strings[b]) > max_bt_size)
             max_bt_size = strlen(bt_strings[b]);
-    if (max_bt_size > NC_MAX_NAME)
-        max_bt_size = NC_MAX_NAME;
+    if (max_bt_size > PIO_MAX_NAME)
+        max_bt_size = PIO_MAX_NAME;
 
     /* Copy the backtrace into one long string. */
     char full_bt[max_bt_size * bt_size + bt_size + 1];
@@ -1446,7 +1446,7 @@ int pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int *
         *max_maplen = max_maplen_in;
 
     /* Read title attribute, if it is in the file. */
-    char title_in[NC_MAX_NAME + 1];
+    char title_in[PIO_MAX_NAME + 1];
     ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_TITLE_ATT_NAME, title_in);
     if (ret == PIO_NOERR)
     {
@@ -1464,7 +1464,7 @@ int pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int *
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Read history attribute, if it is in the file. */
-    char history_in[NC_MAX_NAME + 1];
+    char history_in[PIO_MAX_NAME + 1];
     ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_HISTORY_ATT_NAME, history_in);
     if (ret == PIO_NOERR)
     {
@@ -1482,7 +1482,7 @@ int pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int *
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Read source attribute. */
-    char source_in[NC_MAX_NAME + 1];
+    char source_in[PIO_MAX_NAME + 1];
     if ((ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_SOURCE_ATT_NAME, source_in)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (source)
@@ -1740,7 +1740,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* User must provide valid input for these parameters. */
-    if (!ncidp || !iotype || !filename || strlen(filename) > NC_MAX_NAME)
+    if (!ncidp || !iotype || !filename || strlen(filename) > PIO_MAX_NAME)
         return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* A valid iotype must be specified. */

--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -171,6 +171,11 @@ module pio_types
 !!  - PIO_int :  4-byte integers
 !!  - PIO_char : character
 !<
+   integer, public, parameter :: PIO_MAX_DIMS_UB = 1024
+   integer, public, parameter :: PIO_MAX_ATTRS_UB = 8192
+   integer, public, parameter :: PIO_MAX_VARS_UB = 8192
+   integer, public, parameter :: PIO_MAX_NAME_UB = 1024
+   integer, public, parameter :: PIO_MAX_VAR_DIMS_UB = 1024
 #ifdef _PNETCDF
 #include <pnetcdf.inc>   /* _EXTERNAL */
    integer, public, parameter :: PIO_global = nf_global
@@ -185,8 +190,11 @@ module pio_types
    integer, public, parameter :: PIO_CLOBBER = nf_clobber
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
    integer, public, parameter :: PIO_NOFILL = nf_nofill
-   integer, public, parameter :: PIO_MAX_NAME = nf_max_name
-   integer, public, parameter :: PIO_MAX_VAR_DIMS = nf_max_var_dims
+   integer, public, parameter :: PIO_MAX_DIMS = min(nf_max_dims, PIO_MAX_DIMS_UB)
+   integer, public, parameter :: PIO_MAX_ATTRS = min(nf_max_attrs, PIO_MAX_ATTRS_UB)
+   integer, public, parameter :: PIO_MAX_VARS = min(nf_max_vars, PIO_MAX_VARS_UB)
+   integer, public, parameter :: PIO_MAX_NAME = min(nf_max_name, PIO_MAX_NAME_UB)
+   integer, public, parameter :: PIO_MAX_VAR_DIMS = min(nf_max_var_dims, PIO_MAX_VAR_DIMS_UB)
    integer, public, parameter :: PIO_64BIT_OFFSET = nf_64bit_offset
    integer, public, parameter :: PIO_64BIT_DATA = nf_64bit_data
    integer, public, parameter :: PIO_FILL_INT = nf_fill_int;
@@ -208,8 +216,11 @@ module pio_types
    integer, public, parameter :: PIO_CLOBBER = nf_clobber
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
    integer, public, parameter :: PIO_NOFILL = nf_nofill
-   integer, public, parameter :: PIO_MAX_NAME = nf_max_name
-   integer, public, parameter :: PIO_MAX_VAR_DIMS = nf_max_var_dims
+   integer, public, parameter :: PIO_MAX_DIMS = min(nf_max_dims, PIO_MAX_DIMS_UB)
+   integer, public, parameter :: PIO_MAX_ATTRS = min(nf_max_attrs, PIO_MAX_ATTRS_UB)
+   integer, public, parameter :: PIO_MAX_VARS = min(nf_max_vars, PIO_MAX_VARS_UB)
+   integer, public, parameter :: PIO_MAX_NAME = min(nf_max_name, PIO_MAX_NAME_UB)
+   integer, public, parameter :: PIO_MAX_VAR_DIMS = min(nf_max_var_dims, PIO_MAX_VAR_DIMS_UB)
    integer, public, parameter :: PIO_64BIT_OFFSET = nf_64bit_offset
    integer, public, parameter :: PIO_64BIT_DATA = 0
    integer, public, parameter :: PIO_FILL_INT = nf_fill_int;
@@ -222,6 +233,9 @@ module pio_types
    integer, public, parameter :: PIO_int    = 4
    integer, public, parameter :: PIO_char   = 2
    integer, public, parameter :: PIO_noerr  = 0
+   integer, public, parameter :: PIO_MAX_DIMS = PIO_MAX_DIMS_UB
+   integer, public, parameter :: PIO_MAX_ATTRS = PIO_MAX_ATTRS_UB
+   integer, public, parameter :: PIO_MAX_VARS = PIO_MAX_VARS_UB
    integer, public, parameter :: PIO_MAX_NAME = 25
    integer, public, parameter :: PIO_MAX_VAR_DIMS = 6
    integer, public, parameter :: PIO_CLOBBER = 10

--- a/tests/cunit/test_async_3proc.c
+++ b/tests/cunit/test_async_3proc.c
@@ -77,12 +77,12 @@ int main(int argc, char **argv)
             {
                 for (int flv = 0; flv < num_flavors; flv++)
                 {
-                    char filename[NC_MAX_NAME + 1]; /* Test filename. */
+                    char filename[PIO_MAX_NAME + 1]; /* Test filename. */
                     int my_comp_idx = 0; /* Index in iosysid array. */
 
                     for (int sample = 0; sample < NUM_SAMPLES; sample++)
                     {
-                        char iotype_name[NC_MAX_NAME + 1];
+                        char iotype_name[PIO_MAX_NAME + 1];
 
                         /* Create a filename. */
                         if ((ret = get_iotype_name(flavor[flv], iotype_name)))

--- a/tests/cunit/test_async_4proc.c
+++ b/tests/cunit/test_async_4proc.c
@@ -70,12 +70,12 @@ int main(int argc, char **argv)
             {
                 for (int flv = 0; flv < num_flavors; flv++)
                 {
-                    char filename[NC_MAX_NAME + 1]; /* Test filename. */
+                    char filename[PIO_MAX_NAME + 1]; /* Test filename. */
                     int my_comp_idx = 0; /* Index in iosysid array. */
 
                     for (int sample = 0; sample < NUM_SAMPLES; sample++)
                     {
-                        char iotype_name[NC_MAX_NAME + 1];
+                        char iotype_name[PIO_MAX_NAME + 1];
 
                         /* Create a filename. */
                         if ((ret = get_iotype_name(flavor[flv], iotype_name)))

--- a/tests/cunit/test_async_simple.c
+++ b/tests/cunit/test_async_simple.c
@@ -88,8 +88,8 @@ int main(int argc, char **argv)
 
                 for (int sample = 0; sample < NUM_SAMPLES; sample++)
                 {
-                    char filename[NC_MAX_NAME + 1]; /* Test filename. */
-                    char iotype_name[NC_MAX_NAME + 1];
+                    char filename[PIO_MAX_NAME + 1]; /* Test filename. */
+                    char iotype_name[PIO_MAX_NAME + 1];
 
                     /* Create a filename. */
                     if ((ret = get_iotype_name(flavor[flv], iotype_name)))

--- a/tests/cunit/test_common.c
+++ b/tests/cunit/test_common.c
@@ -84,13 +84,13 @@ get_iotypes(int *num_flavors, int *flavors)
  *
  * @param iotype the IO type
  * @param name pointer that will get name of IO type. Must have enough
- * memory allocated (NC_MAX_NAME + 1 works.)
+ * memory allocated (PIO_MAX_NAME + 1 works.)
  * @returns 0 for success, error code otherwise.
  * @internal
  */
 int get_iotype_name(int iotype, char *name)
 {
-    char flavor_name[NUM_FLAVORS][NC_MAX_NAME + 1] = {"pnetcdf", "classic",
+    char flavor_name[NUM_FLAVORS][PIO_MAX_NAME + 1] = {"pnetcdf", "classic",
                                                       "serial4", "parallel4"};
 
     /* Check inputs. */
@@ -263,7 +263,7 @@ int
 test_inq_type(int ncid, int format)
 {
 #define NUM_TYPES 11
-    char type_name[NC_MAX_NAME + 1];
+    char type_name[PIO_MAX_NAME + 1];
     PIO_Offset type_size;
     nc_type xtype[NUM_TYPES] = {NC_CHAR, NC_BYTE, NC_SHORT, NC_INT, NC_FLOAT, NC_DOUBLE,
                                 NC_UBYTE, NC_USHORT, NC_UINT, NC_INT64, NC_UINT64};
@@ -504,9 +504,9 @@ check_nc_sample_1(int iosysid, int format, char *filename, int my_rank, int *nci
     int ret;
     int ndims, nvars, ngatts, unlimdimid;
     int ndims2, nvars2, ngatts2, unlimdimid2;
-    char dimname[NC_MAX_NAME + 1];
+    char dimname[PIO_MAX_NAME + 1];
     PIO_Offset dimlen;
-    char varname[NC_MAX_NAME + 1];
+    char varname[PIO_MAX_NAME + 1];
     nc_type vartype;
     int varndims, vardimids, varnatts;
 
@@ -563,7 +563,7 @@ check_nc_sample_1(int iosysid, int format, char *filename, int my_rank, int *nci
         return ERR_WRONG;
 
     /* Check out the variable. */
-    if ((ret = PIOc_inq_var(ncid, 0, varname, NC_MAX_NAME + 1, &vartype, &varndims, &vardimids, &varnatts)))
+    if ((ret = PIOc_inq_var(ncid, 0, varname, PIO_MAX_NAME + 1, &vartype, &varndims, &vardimids, &varnatts)))
         return ret;
     if (strcmp(varname, VAR_NAME_S1) || vartype != NC_INT || varndims != NDIM_S1 ||
         vardimids != 0 || varnatts != 0)
@@ -605,7 +605,7 @@ create_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nc
         return ret;
 
     /* Define a dimension. */
-    char dimname2[NC_MAX_NAME + 1];
+    char dimname2[PIO_MAX_NAME + 1];
     printf("%d defining dimension %s\n", my_rank, DIM_NAME_S2);
     if ((ret = PIOc_def_dim(ncid, FIRST_DIM_NAME_S2, DIM_LEN_S2, &dimid)))
         return ret;
@@ -617,11 +617,11 @@ create_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nc
         return ret;
 
     /* Define a 1-D variable. */
-    char varname2[NC_MAX_NAME + 1];
+    char varname2[PIO_MAX_NAME + 1];
     printf("%d defining variable %s\n", my_rank, VAR_NAME_S2);
     if ((ret = PIOc_def_var(ncid, FIRST_VAR_NAME_S2, NC_INT, NDIM_S2, &dimid, &varid)))
         return ret;
-    if ((ret = PIOc_inq_varname(ncid, 0, varname2, NC_MAX_NAME + 1)))
+    if ((ret = PIOc_inq_varname(ncid, 0, varname2, PIO_MAX_NAME + 1)))
         return ret;
     if (strcmp(varname2, FIRST_VAR_NAME_S2))
         return ERR_WRONG;
@@ -634,7 +634,7 @@ create_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nc
     short short_att_data = ATT_VALUE_S2;
     float float_att_data = ATT_VALUE_S2;
     double double_att_data = ATT_VALUE_S2;
-    char attname2[NC_MAX_NAME + 1];
+    char attname2[PIO_MAX_NAME + 1];
     /* Write an att and rename it. */
     if ((ret = PIOc_put_att_int(ncid, NC_GLOBAL, FIRST_ATT_NAME_S2, NC_INT, 1, &att_data)))
         return ret;
@@ -710,14 +710,14 @@ check_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nci
     int ndims, nvars, ngatts, unlimdimid;
     int ndims2, nvars2, ngatts2, unlimdimid2;
     int dimid2;
-    char dimname[NC_MAX_NAME + 1];
+    char dimname[PIO_MAX_NAME + 1];
     PIO_Offset dimlen;
-    char dimname2[NC_MAX_NAME + 1];
+    char dimname2[PIO_MAX_NAME + 1];
     PIO_Offset dimlen2;
-    char varname[NC_MAX_NAME + 1];
+    char varname[PIO_MAX_NAME + 1];
     nc_type vartype;
     int varndims, vardimids, varnatts;
-    char varname2[NC_MAX_NAME + 1];
+    char varname2[PIO_MAX_NAME + 1];
     nc_type vartype2;
     int varndims2, vardimids2, varnatts2;
     int varid2;
@@ -727,7 +727,7 @@ check_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nci
     double double_att_data;
     nc_type atttype;
     PIO_Offset attlen;
-    char myattname[NC_MAX_NAME + 1];
+    char myattname[PIO_MAX_NAME + 1];
     int myid;
     PIO_Offset start[NDIM_S2] = {0}, count[NDIM_S2] = {DIM_LEN_S2};
     int data_in[DIM_LEN_S2];
@@ -799,14 +799,14 @@ check_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nci
         return ERR_WRONG;
 
     /* Check out the variable. */
-    if ((ret = PIOc_inq_var(ncid, 0, varname, NC_MAX_NAME + 1, &vartype, &varndims, &vardimids, &varnatts)))
+    if ((ret = PIOc_inq_var(ncid, 0, varname, PIO_MAX_NAME + 1, &vartype, &varndims, &vardimids, &varnatts)))
         return ERR_CHECK;
     if (strcmp(varname, VAR_NAME_S2) || vartype != NC_INT || varndims != NDIM_S2 ||
         vardimids != 0 || varnatts != 0)
         return ERR_WRONG;
 
     /* Check the other functions that get these values. */
-    if ((ret = PIOc_inq_varname(ncid, 0, varname2, NC_MAX_NAME + 1)))
+    if ((ret = PIOc_inq_varname(ncid, 0, varname2, PIO_MAX_NAME + 1)))
         return ERR_CHECK;
     if (strcmp(varname2, VAR_NAME_S2))
         return ERR_WRONG;

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -176,7 +176,7 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
                 }
                 else
                 {
-                    int varid_big = NC_MAX_VARS + TEST_VAL_42;
+                    int varid_big = PIO_MAX_VARS + TEST_VAL_42;
 
                     /* These will not work. */
                     if (PIOc_write_darray_multi(ncid + TEST_VAL_42, &varid, ioid, 1, arraylen, test_data, &frame,
@@ -285,7 +285,7 @@ int test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
 {
 #define NUM_TYPES_TO_TEST 3
     int ioid;
-    char filename[NC_MAX_NAME + 1];
+    char filename[PIO_MAX_NAME + 1];
     int pio_type[NUM_TYPES_TO_TEST] = {PIO_INT, PIO_FLOAT, PIO_DOUBLE};
     int dim_len_2d[NDIM2] = {X_DIM_LEN, Y_DIM_LEN};
     int ret; /* Return code. */

--- a/tests/cunit/test_darray_multi.c
+++ b/tests/cunit/test_darray_multi.c
@@ -384,7 +384,7 @@ int test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
     int pio_type[NUM_TYPES_TO_TEST] = {PIO_BYTE, PIO_CHAR, PIO_SHORT, PIO_INT, PIO_FLOAT, PIO_DOUBLE};
 #endif /* _NETCDF4 */
     int ioid;
-    char filename[NC_MAX_NAME + 1];
+    char filename[PIO_MAX_NAME + 1];
     int dim_len_2d[NDIM2] = {X_DIM_LEN, Y_DIM_LEN};
     int ret; /* Return code. */
 

--- a/tests/cunit/test_decomp_uneven.c
+++ b/tests/cunit/test_decomp_uneven.c
@@ -136,7 +136,7 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
                 dim_len[0], dim_len[1], dim_len[2]);
 
         /* Create history string. */
-        strncat(history, filename, NC_MAX_NAME - strlen(TEST_DECOMP_HISTORY));
+        strncat(history, filename, PIO_MAX_NAME - strlen(TEST_DECOMP_HISTORY));
 
         printf("writing decomp file %s\n", filename);
         if ((ret = PIOc_write_nc_decomp(iosysid, filename, 0, ioid, title, history, 0)))

--- a/tests/cunit/test_intercomm2.c
+++ b/tests/cunit/test_intercomm2.c
@@ -58,14 +58,14 @@ int check_file(int iosysid, int format, char *filename, int my_rank)
     int ndims, nvars, ngatts, unlimdimid;
     int ndims2, nvars2, ngatts2, unlimdimid2;
     int dimid2;
-    char dimname[NC_MAX_NAME + 1];
+    char dimname[PIO_MAX_NAME + 1];
     PIO_Offset dimlen;
-    char dimname2[NC_MAX_NAME + 1];
+    char dimname2[PIO_MAX_NAME + 1];
     PIO_Offset dimlen2;
-    char varname[NC_MAX_NAME + 1];
+    char varname[PIO_MAX_NAME + 1];
     nc_type vartype;
     int varndims, vardimids, varnatts;
-    char varname2[NC_MAX_NAME + 1];
+    char varname2[PIO_MAX_NAME + 1];
     nc_type vartype2;
     int varndims2, vardimids2, varnatts2;
     int varid2;
@@ -161,14 +161,14 @@ int check_file(int iosysid, int format, char *filename, int my_rank)
         ERR(ERR_WRONG);
 
     /* Check out the variable. */
-    if ((ret = PIOc_inq_var(ncid, 0, varname, NC_MAX_NAME + 1, &vartype, &varndims, &vardimids, &varnatts)))
+    if ((ret = PIOc_inq_var(ncid, 0, varname, PIO_MAX_NAME + 1, &vartype, &varndims, &vardimids, &varnatts)))
         ERR(ret);
     if (strcmp(varname, VAR_NAME) || vartype != NC_INT || varndims != NDIM ||
         vardimids != 0 || varnatts != 0)
         ERR(ERR_WRONG);
 
     /* Check the other functions that get these values. */
-    if ((ret = PIOc_inq_varname(ncid, 0, varname2, NC_MAX_NAME + 1)))
+    if ((ret = PIOc_inq_varname(ncid, 0, varname2, PIO_MAX_NAME + 1)))
         ERR(ret);
     if (strcmp(varname2, VAR_NAME))
         ERR(ERR_WRONG);
@@ -204,7 +204,7 @@ int check_file(int iosysid, int format, char *filename, int my_rank)
     /* Check out the global attributes. */
     nc_type atttype;
     PIO_Offset attlen;
-    char myattname[NC_MAX_NAME + 1];
+    char myattname[PIO_MAX_NAME + 1];
     int myid;
     if ((ret = PIOc_inq_att(ncid, NC_GLOBAL, ATT_NAME, &atttype, &attlen)))
         ERR(ret);
@@ -281,7 +281,7 @@ int main(int argc, char **argv)
     int flavor[NUM_FLAVORS]; /* iotypes for the supported netCDF IO flavors. */
 
     /* Names for the output files. */
-    char filename[NUM_FLAVORS][NC_MAX_NAME + 1];
+    char filename[NUM_FLAVORS][PIO_MAX_NAME + 1];
 
     /* The ID for the parallel I/O system. */
     int iosysid[COMPONENT_COUNT];
@@ -376,7 +376,7 @@ int main(int argc, char **argv)
                     ERR(ERR_AWFUL);
 
                 /* Test the inq_type function for atomic types. */
-                char type_name[NC_MAX_NAME + 1];
+                char type_name[PIO_MAX_NAME + 1];
                 PIO_Offset type_size;
                 nc_type xtype[NUM_TYPES] = {NC_CHAR, NC_BYTE, NC_SHORT, NC_INT, NC_FLOAT, NC_DOUBLE,
                                             NC_UBYTE, NC_USHORT, NC_UINT, NC_INT64, NC_UINT64};
@@ -397,7 +397,7 @@ int main(int argc, char **argv)
                 }
 
                 /* Define a dimension. */
-                char dimname2[NC_MAX_NAME + 1];
+                char dimname2[PIO_MAX_NAME + 1];
 		printf("%d test_intercomm2 defining dimension %s\n", my_rank, DIM_NAME);
                 if ((ret = PIOc_def_dim(ncid, FIRST_DIM_NAME, DIM_LEN, &dimid)))
                     ERR(ret);
@@ -417,11 +417,11 @@ int main(int argc, char **argv)
                     ERR(ERR_WRONG);
 
                 /* Define a 1-D variable. */
-                char varname2[NC_MAX_NAME + 1];
+                char varname2[PIO_MAX_NAME + 1];
 		printf("%d test_intercomm2 defining variable %s\n", my_rank, VAR_NAME);
                 if ((ret = PIOc_def_var(ncid, FIRST_VAR_NAME, NC_INT, NDIM, &dimid, &varid)))
                     ERR(ret);
-                if ((ret = PIOc_inq_varname(ncid, 0, varname2, NC_MAX_NAME + 1)))
+                if ((ret = PIOc_inq_varname(ncid, 0, varname2, PIO_MAX_NAME + 1)))
                     ERR(ret);
                 if (strcmp(varname2, FIRST_VAR_NAME))
                     ERR(ERR_WRONG);
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
                 short short_att_data = ATT_VALUE;
                 float float_att_data = ATT_VALUE;
                 double double_att_data = ATT_VALUE;
-                char attname2[NC_MAX_NAME + 1];
+                char attname2[PIO_MAX_NAME + 1];
 
                 /* Write an att and rename it. */
                 if ((ret = PIOc_put_att_int(ncid, NC_GLOBAL, FIRST_ATT_NAME, NC_INT, 1, &att_data)))

--- a/tests/cunit/test_iosystem2_simple.c
+++ b/tests/cunit/test_iosystem2_simple.c
@@ -144,8 +144,8 @@ int main(int argc, char **argv)
         int ncid2;
         for (int i = 0; i < num_flavors; i++)
         {
-            char fn[NUM_FILES][NC_MAX_NAME + 1];
-            char dimname[NUM_FILES][NC_MAX_NAME + 1];
+            char fn[NUM_FILES][PIO_MAX_NAME + 1];
+            char dimname[NUM_FILES][PIO_MAX_NAME + 1];
 
             /* Create the test files. */
             for (int f = 0; f < NUM_FILES; f++)
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
                 return ret;
 
             /* Check the first file. */
-            char dimname_in[NC_MAX_NAME + 1];
+            char dimname_in[PIO_MAX_NAME + 1];
             if ((ret = PIOc_inq_dimname(ncid, 0, dimname_in)))
                 return ret;
             printf("%d ncid dimname_in = %s should be %s\n", my_rank, dimname_in, dimname[0]);

--- a/tests/cunit/test_iosystem2_simple2.c
+++ b/tests/cunit/test_iosystem2_simple2.c
@@ -75,12 +75,12 @@ int main(int argc, char **argv)
 
         for (int flv = 0; flv < num_flavors; flv++)
         {
-            char filename[NUM_SAMPLES][NC_MAX_NAME + 1]; /* Test filename. */
+            char filename[NUM_SAMPLES][PIO_MAX_NAME + 1]; /* Test filename. */
             int sample_ncid[NUM_SAMPLES];
 
             for (int sample = 0; sample < NUM_SAMPLES; sample++)
             {
-                char iotype_name[NC_MAX_NAME + 1];
+                char iotype_name[PIO_MAX_NAME + 1];
 
                 /* Create a filename. */
                 if ((ret = get_iotype_name(flavor[flv], iotype_name)))

--- a/tests/cunit/test_iosystem3_simple2.c
+++ b/tests/cunit/test_iosystem3_simple2.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
     int my_rank; /* Zero-based rank of processor. */
     int ntasks; /* Number of processors involved in current execution. */
     int iosysid_world; /* The ID for the parallel I/O system. */
-    char fname0[NC_MAX_NAME + 1];
+    char fname0[PIO_MAX_NAME + 1];
     int ncid;
     int num_flavors; /* Number of PIO netCDF flavors in this build. */
     int flavor[NUM_FLAVORS]; /* iotypes for the supported netCDF IO flavors. */

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -540,10 +540,10 @@ int test_iotypes(int my_rank)
 int check_strerror_netcdf(int my_rank)
 {
 #ifdef _NETCDF
-#define NUM_NETCDF_TRIES 5
-    int errcode[NUM_NETCDF_TRIES] = {PIO_EBADID, NC4_LAST_ERROR - 1, 0, 1, -600};
+#define NUM_NETCDF_TRIES 4
+    int errcode[NUM_NETCDF_TRIES] = {PIO_EBADID, 0, 1, -600};
     const char *expected[NUM_NETCDF_TRIES] = {"NetCDF: Not a valid ID",
-                                              "Unknown Error: Unrecognized error code", "No error",
+                                              "No error",
                                               nc_strerror(1), "Unknown Error: Unrecognized error code"};
     int ret;
 
@@ -634,13 +634,13 @@ int check_strerror_pnetcdf(int my_rank)
  */
 int check_strerror_pio(int my_rank)
 {
-#define NUM_PIO_TRIES 6
+#define NUM_PIO_TRIES 5
     int errcode[NUM_PIO_TRIES] = {PIO_EBADID,
-                                  NC_ENOTNC3, NC4_LAST_ERROR - 1, 0, 1,
+                                  NC_ENOTNC3, 0, 1,
                                   PIO_EBADIOTYPE};
     const char *expected[NUM_PIO_TRIES] = {"NetCDF: Not a valid ID",
                                            "NetCDF: Attempting netcdf-3 operation on netcdf-4 file",
-                                           "Unknown Error: Unrecognized error code", "No error",
+                                           "No error",
 #ifdef _NETCDF
                                            nc_strerror(1), "Bad IO type"};
 #else /* Assume that _PNETCDF is defined. */

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -906,13 +906,13 @@ int test_names(int iosysid, int num_flavors, int *flavor, int my_rank,
             return ERR_WRONG;
         if (PIOc_setframe(ncid, -1, 0) != PIO_EINVAL)
             return ERR_WRONG;
-        if (PIOc_setframe(ncid, NC_MAX_VARS + 1, 0) != PIO_EINVAL)
+        if (PIOc_setframe(ncid, PIO_MAX_VARS + 1, 0) != PIO_EINVAL)
             return ERR_WRONG;
         if (PIOc_advanceframe(ncid + TEST_VAL_42, 0) != PIO_EBADID)
             return ERR_WRONG;
         if (PIOc_advanceframe(ncid, -1) != PIO_EINVAL)
             return ERR_WRONG;
-        if (PIOc_advanceframe(ncid, NC_MAX_VARS + 1) != PIO_EINVAL)
+        if (PIOc_advanceframe(ncid, PIO_MAX_VARS + 1) != PIO_EINVAL)
             return ERR_WRONG;
 
         /* Check the dimension names. */
@@ -1642,8 +1642,8 @@ int test_decomp_internal(int my_test_size, int my_rank, int iosysid, int dim_len
                          MPI_Comm test_comm, int async)
 {
     int ioid;
-    char filename[NC_MAX_NAME + 1];    /* Test decomp filename. */
-    char nc_filename[NC_MAX_NAME + 1]; /* Test decomp filename (netcdf version). */
+    char filename[PIO_MAX_NAME + 1];    /* Test decomp filename. */
+    char nc_filename[PIO_MAX_NAME + 1]; /* Test decomp filename (netcdf version). */
     iosystem_desc_t *ios; /* IO system info. */
     int ret;
 
@@ -1836,7 +1836,7 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
                        MPI_Comm test_comm, int async)
 {
     int ioid;
-    char nc_filename[NC_MAX_NAME + 1]; /* Test decomp filename (netcdf version). */
+    char nc_filename[PIO_MAX_NAME + 1]; /* Test decomp filename (netcdf version). */
     int ret;
 
     /* This will be our file name for writing out decompositions. */
@@ -1986,7 +1986,7 @@ int test_decomp_public_2(int my_test_size, int my_rank, int iosysid, int dim_len
                          MPI_Comm test_comm, int async)
 {
     int ioid;
-    char nc_filename[NC_MAX_NAME + 1]; /* Test decomp filename (netcdf version). */
+    char nc_filename[PIO_MAX_NAME + 1]; /* Test decomp filename (netcdf version). */
     int ret;
 
     /* This will be our file name for writing out decompositions. */
@@ -2016,7 +2016,7 @@ int test_decomp_2(int my_test_size, int my_rank, int iosysid, int dim_len,
                   MPI_Comm test_comm, int async)
 {
     int ioid;
-    char nc_filename[NC_MAX_NAME + 1]; /* Test decomp filename (netcdf version). */
+    char nc_filename[PIO_MAX_NAME + 1]; /* Test decomp filename (netcdf version). */
     int ret;
 
     /* This will be our file name for writing out decompositions. */
@@ -2070,8 +2070,8 @@ int test_all(int iosysid, int num_flavors, int *flavor, int my_rank, MPI_Comm te
 {
     int ioid;
     int my_test_size;
-    char filename[NC_MAX_NAME + 1];
-    char nc_filename[NC_MAX_NAME + 1];
+    char filename[PIO_MAX_NAME + 1];
+    char nc_filename[PIO_MAX_NAME + 1];
     int ret; /* Return code. */
 
     if ((ret = MPI_Comm_size(test_comm, &my_test_size)))

--- a/tests/cunit/test_pioc_unlim.c
+++ b/tests/cunit/test_pioc_unlim.c
@@ -245,7 +245,7 @@ int test_all(int iosysid, int num_flavors, int *flavor, int my_rank, MPI_Comm te
     int ncid;
     int varid;
     int my_test_size;
-    char filename[NC_MAX_NAME + 1];
+    char filename[PIO_MAX_NAME + 1];
     int ret; /* Return code. */
 
     if ((ret = MPI_Comm_size(test_comm, &my_test_size)))

--- a/tests/general/test_memleak.c
+++ b/tests/general/test_memleak.c
@@ -66,7 +66,7 @@ char err_buffer[MPI_MAX_ERROR_STRING];
 int resultlen;
 
 /** The dimension names. */
-char dim_name[NDIM][NC_MAX_NAME + 1] = {"timestep", "x", "y"};
+char dim_name[NDIM][PIO_MAX_NAME + 1] = {"timestep", "x", "y"};
 
 /** Length of the dimensions in the sample data. */
 int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
@@ -109,7 +109,7 @@ main(int argc, char **argv)
      * (serial4 and parallel4) will be in netCDF-4/HDF5
      * format. All four can be read by the netCDF library, and all
      * will contain the same contents. */
-    char filename[NUM_NETCDF_FLAVORS][NC_MAX_NAME + 1] = {"test_nc4_pnetcdf.nc",
+    char filename[NUM_NETCDF_FLAVORS][PIO_MAX_NAME + 1] = {"test_nc4_pnetcdf.nc",
 							  "test_nc4_classic.nc",
 							  "test_nc4_serial4.nc",
 							  "test_nc4_parallel4.nc"};


### PR DESCRIPTION
This PR adds the support for PnetCDF 1.9.0 or higher versions.

- Replace some NC_MAX_XXXX constants with corresponding PIO
constants PIO_MAX_XXXX to have a better control over them

- Add upper limits for PIO constants like PIO_MAX_VARS. In newer
versions of PnetCDF, some constants like NC_MAX_VARS have
been raised to a significantly large value, i.e. NC_MAX_INT

- Create some related PIO constants like PIO_MAX_ATTRS
with upper limits (for future use)

- Remove an error code (NC4_LAST_ERROR - 1) used to test
PIOc_strerror. NC4_LAST_ERROR constant may or may not
have the same value in NetCDF and PnetCDF

Fixes #77