### PR TITLE
Import some patches for ADIOS IO type

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -25,6 +25,9 @@
 #include <pnetcdf.h>
 #endif
 #ifdef _ADIOS
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <adios.h>
 #include <adios_read.h> // we only need adios_type_size() at the moment
 #define _ADIOS_ALL_PROCS 1  /* ADIOS: assume all procs are also IO tasks */

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -553,12 +553,37 @@ static void PIOc_write_decomp_adios(file_desc_t *file, int ioid)
     io_desc_t *iodesc = pio_get_iodesc_from_id(ioid);
     char name[32], ldim[32];
     sprintf(name, "/__pio__/decomp/%d", ioid);
-    sprintf(ldim, "%d", iodesc->maplen);
+
     enum ADIOS_DATATYPES type = adios_integer; //PIOc_get_adios_type(iodesc->piotype);
     if (sizeof(PIO_Offset) == 8)
-       type = adios_long;
-    int64_t vid = adios_define_var(file->adios_group, name, "", type, ldim,"","");
-    adios_write_byid(file->adios_fh, vid, iodesc->map);
+        type = adios_long;
+
+    if (iodesc->maplen!=1) {
+        sprintf(ldim, "%d", iodesc->maplen);
+        int64_t vid = adios_define_var(file->adios_group, name, "", type, ldim,"","");
+        adios_write_byid(file->adios_fh, vid, iodesc->map);
+    } else { // Handle the case where maplen is 1
+        int maplen = iodesc->maplen+1;
+        char *mapbuf = NULL;
+        sprintf(ldim, "%d", maplen);
+        if (type==adios_integer) {
+            int *temp_mapbuf;
+            temp_mapbuf    = (int*)malloc(sizeof(int)*maplen);
+            temp_mapbuf[0] = iodesc->map[0];
+            temp_mapbuf[1] = 0;
+            mapbuf = (char*)temp_mapbuf;
+        } else {
+            long *temp_mapbuf;
+            temp_mapbuf    = (long*)malloc(sizeof(long)*maplen);
+            temp_mapbuf[0] = iodesc->map[0];
+            temp_mapbuf[1] = 0;
+            mapbuf = (char*)temp_mapbuf;
+        }
+        int64_t vid = adios_define_var(file->adios_group, name, "", type, ldim,"","");
+        adios_write_byid(file->adios_fh, vid, mapbuf);
+        free(mapbuf);
+    }
+
 #ifdef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
     if (file->adios_iomaster == MPI_ROOT)
 #else
@@ -636,6 +661,31 @@ static void *PIOc_convert_buffer_adios(file_desc_t *file, io_desc_t *iodesc,
 	return buf;
 }
 
+#define ADIOS_COPY_ONE(temp_buf,array,var_type) \
+{ \
+    temp_buf = (var_type*)malloc(2*sizeof(var_type)); \
+    memcpy(temp_buf,array,sizeof(var_type)); \
+}
+
+void *PIOc_copy_one_element_adios(void *array, adios_var_desc_t *av)
+{
+    void *temp_buf = NULL;
+    if (av->nc_type==PIO_DOUBLE) {
+        ADIOS_COPY_ONE(temp_buf,array,double);
+    } else if (av->nc_type==PIO_FLOAT || av->nc_type==PIO_REAL) {
+        ADIOS_COPY_ONE(temp_buf,array,float);
+    } else if (av->nc_type==PIO_INT || av->nc_type==PIO_UINT) {
+        ADIOS_COPY_ONE(temp_buf,array,int);
+    } else if (av->nc_type==PIO_SHORT || av->nc_type==PIO_USHORT) {
+        ADIOS_COPY_ONE(temp_buf,array,short int);
+    } else if (av->nc_type==PIO_INT64 || av->nc_type==PIO_UINT64) {
+        ADIOS_COPY_ONE(temp_buf,array,int64_t);
+    } else if (av->nc_type==PIO_CHAR || av->nc_type==PIO_BYTE || av->nc_type==PIO_UBYTE) {
+        ADIOS_COPY_ONE(temp_buf,array,char);
+    }
+    return temp_buf;
+}
+
 static int PIOc_write_darray_adios(
         file_desc_t *file, int varid, int ioid, io_desc_t *iodesc,
         PIO_Offset arraylen, void *array, void *fillvalue)
@@ -645,6 +695,14 @@ static int PIOc_write_darray_adios(
         return pio_err(file->iosystem, file, PIO_EBADID, __FILE__, __LINE__);
 
     adios_var_desc_t * av = &(file->adios_vars[varid]);
+
+    void *temp_buf = NULL;
+    if (arraylen==1) { // Handle the case where there is one array element
+        arraylen++;
+        temp_buf = PIOc_copy_one_element_adios(array,av);
+        array = temp_buf;
+    }
+
     if (av->adios_varid == 0)
     {
         /* First we need to define the variable now that we know it's decomposition */
@@ -710,6 +768,8 @@ static int PIOc_write_darray_adios(
 
     if (buf_needs_free)
         free(buf);
+
+    if (temp_buf!=NULL) free(temp_buf);
 
     return PIO_NOERR;
 }

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -1276,12 +1276,17 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     if (d < av->ndims-1)
                         strcat(offs,",");
                 }
-                if (av->adios_varid == 0)
-                {
+
+                // TAHSIN
+                // PIOc_put_var may be called multiple times with different start,count values for a variable
+                // ADIOS should output data for each of those calls not just when the variable is not defined
+                // if (av->adios_varid == 0)
+                // {
                     /*printf("ADIOS variable %s on io rank %d define gdims=\"%s\", ldims=\"%s\", offsets=\"%s\"\n",
                             av->name, ios->io_rank, gdims, ldims, offs);*/
                     av->adios_varid = adios_define_var(file->adios_group, av->name, "", av->adios_type, ldims,gdims,offs);
-                }
+                // } // TAHSIN
+
                 adios_write_byid(file->adios_fh, av->adios_varid, buf);
                 char* dimnames[6];
                 /* record the NC dimensions in an attribute, including the unlimited dimension */

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1847,40 +1847,52 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 #ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS) 
 	{
-            LOG((2, "Calling adios_open mode = %d", file->mode));
-            /* Create a new ADIOS variable group, names the same as the filename for
-             * lack of better solution here */
-            int len = strlen(filename);
-            file->filename = malloc(len+3+3);
-            sprintf(file->filename, "%s.bp", filename);
-            adios_declare_group(&file->adios_group, file->filename, NULL, adios_stat_default);
-            int do_aggregate = (ios->num_comptasks != ios->num_iotasks);
-            if (do_aggregate)
-            {
-                sprintf(file->transport,"%s","MPI_AGGREGATE");
-                /* sprintf(file->params,"num_aggregators=%d,striping=0,have_metadata_file=0", ios->num_iotasks); */
-                sprintf(file->params,"num_aggregators=%d,random_offset=1,striping_count=1,have_metadata_file=0", 
+		LOG((2, "Calling adios_open mode = %d", file->mode));
+        /* Create a new ADIOS variable group, names the same as the filename for
+         * lack of better solution here */
+		int len = strlen(filename);
+		file->filename = malloc(len+3+3);
+		sprintf(file->filename, "%s.bp", filename);
+
+		ierr = PIO_NOERR;
+		if (file->mode & PIO_NOCLOBBER) { /* check adios file/folder exists */
+			struct stat sf, sd;
+			char *filefolder = malloc(strlen(file->filename)+6);
+			sprintf(filefolder,"%s.dir",file->filename);
+			if (0==stat(file->filename,&sf) || 0==stat(filefolder,&sd))
+				ierr = PIO_EEXIST;
+			free(filefolder);
+		}
+
+		if (PIO_NOERR==ierr) {
+           	adios_declare_group(&file->adios_group, file->filename, NULL, adios_stat_default);
+           	int do_aggregate = (ios->num_comptasks != ios->num_iotasks);
+           	if (do_aggregate)
+           	{
+               	sprintf(file->transport,"%s","MPI_AGGREGATE");
+               	/* sprintf(file->params,"num_aggregators=%d,striping=0,have_metadata_file=0", ios->num_iotasks); */
+               	sprintf(file->params,"num_aggregators=%d,random_offset=1,striping_count=1,have_metadata_file=0",
 									ios->num_iotasks);
-            }
-            else
-            {
-                sprintf(file->transport,"%s","MPI_AGGREGATE");
-                /* sprintf(file->params,"num_aggregators=%d,striping=0,have_metadata_file=0", ios->num_comptasks/16); */
-                sprintf(file->params,"num_aggregators=%d,random_offset=1,striping_count=1,have_metadata_file=0", 
+           	}
+           	else
+           	{
+              		sprintf(file->transport,"%s","MPI_AGGREGATE");
+               	/* sprintf(file->params,"num_aggregators=%d,striping=0,have_metadata_file=0", ios->num_comptasks/16); */
+               	sprintf(file->params,"num_aggregators=%d,random_offset=1,striping_count=1,have_metadata_file=0",
 									ios->num_comptasks/16);
-                /*sprintf(file->transport,"%s","POSIX");
-                file->params[0] = '\0';*/
-            }
-            /*adios_set_time_aggregation(file->adios_group,100000000,NULL);*/
-            adios_select_method(file->adios_group,file->transport,file->params,"");
-            /*adios_set_max_buffer_size(32);*/
-            ierr = adios_open(&file->adios_fh,file->filename,file->filename,"w", ios->union_comm);
-            memset(file->dim_names, 0, sizeof(file->dim_names));
-            file->num_dim_vars = 0;
-            file->num_vars = 0;
-            file->num_gattrs = 0;
-            file->fillmode = NC_NOFILL;
-            file->n_written_ioids = 0;
+               	/*sprintf(file->transport,"%s","POSIX");
+               	file->params[0] = '\0';*/
+           	}
+           	/*adios_set_time_aggregation(file->adios_group,100000000,NULL);*/
+           	adios_select_method(file->adios_group,file->transport,file->params,"");
+           	/*adios_set_max_buffer_size(32);*/
+           	ierr = adios_open(&file->adios_fh,file->filename,file->filename,"w", ios->union_comm);
+           	memset(file->dim_names, 0, sizeof(file->dim_names));
+           	file->num_dim_vars = 0;
+           	file->num_vars = 0;
+           	file->num_gattrs = 0;
+           	file->fillmode = NC_NOFILL;
+           	file->n_written_ioids = 0;
 
 			if (ios->union_rank==0) 
 				file->adios_iomaster = MPI_ROOT;
@@ -1890,8 +1902,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 			/* Track attributes */
 			file->num_attrs = 0;
 
-            int64_t vid = adios_define_var(file->adios_group, "/__pio__/info/nproc", "", adios_integer, "","","");
-            adios_write_byid(file->adios_fh, vid, &ios->num_uniontasks);
+           	int64_t vid = adios_define_var(file->adios_group, "/__pio__/info/nproc", "", adios_integer, "","","");
+           	adios_write_byid(file->adios_fh, vid, &ios->num_uniontasks);
+		}
 	}
 #endif
 #endif

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -198,7 +198,7 @@ void ProcessGlobalAttributes(ADIOS_FILE **infile, int ncid, DimensionMap& dimens
 	std::string delimiter = "/";
 
 	std::map<std::string,char> processed_attrs;
-	VariableMap var_att_map;
+	std::map<std::string,int>  var_att_map;
 
     for (int i=0; i < infile[0]->nattrs; i++)
     {
@@ -251,8 +251,7 @@ void ProcessGlobalAttributes(ADIOS_FILE **infile, int ncid, DimensionMap& dimens
                		}
             		int varid;
             		PIOc_def_var(ncid, token.c_str(), *nctype, *ndims, dimids, &varid);
-	           		bool timed = false;
-	           		var_att_map[token] = Variable{varid,timed,*nctype};
+	           		var_att_map[token] = varid; 
 
             		free(nctype);
             		free(ndims);
@@ -267,10 +266,8 @@ void ProcessGlobalAttributes(ADIOS_FILE **infile, int ncid, DimensionMap& dimens
 						nc_type piotype = PIOc_get_nctype_from_adios_type(atype);
         				char *attname = ((char*)a.c_str())+token.length()+1;;
         				int len = 1;
-        				if (atype == adios_string)
-            				len = strlen(adata);
-						int nc_varid = var_att_map[token].nc_varid;
-        				PIOc_put_att(ncid, nc_varid, attname, piotype, len, adata);
+        				if (atype == adios_string) len = strlen(adata);
+        				PIOc_put_att(ncid, var_att_map[token], attname, piotype, len, adata);
         				free(adata);
 					}
 				}
@@ -1341,4 +1338,3 @@ int C_API_ConvertBPToNC(const char *infilepath, const char *outfilename, const c
 #ifdef __cplusplus
 }
 #endif
-

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -105,8 +105,7 @@ int InitPIO(MPI_Comm comm, int mpirank, int nproc)
 {
 	int iosysid; 
 
-    if (PIOc_Init_Intracomm(comm, nproc, 1,
-            0, PIO_REARR_SUBSET, &iosysid))
+    if (PIOc_Init_Intracomm(comm, nproc, 1, 0, PIO_REARR_SUBSET, &iosysid))
         throw std::runtime_error("PIO initialization failed\n");
 
 	return iosysid;
@@ -154,13 +153,10 @@ std::vector<int> AssignWriteRanks(int n_bp_writers, MPI_Comm comm, int mpirank, 
 
 void ProcessGlobalFillmode(ADIOS_FILE **infile, int ncid)
 {
-    // cout << "Process Global Fillmode: \n";
- 
-    int asize;
+    int  asize;
     void *fillmode;
     ADIOS_DATATYPES atype;
     adios_get_attr(infile[0], "/__pio__/fillmode", &atype, &asize, &fillmode);
-    // cout << "    set fillmode: " << *(int*)fillmode << std::endl;
     PIOc_set_fill(ncid, *(int*)fillmode, NULL);
     free(fillmode);
 }
@@ -180,7 +176,7 @@ void ProcessVarAttributes(ADIOS_FILE **infile, int adios_varid, std::string varn
         char *attname = infile[0]->attr_namelist[vi->attr_ids[i]]+varname.length()+1;
 		if (debug_out)
         	cout << "        define PIO attribute: " << attname << ""
-             	<< "  type=" << piotype << std::endl;
+             	 << "  type=" << piotype << std::endl;
         int len = 1;
         if (atype == adios_string)
             len = strlen(adata);
@@ -196,7 +192,6 @@ void ProcessGlobalAttributes(ADIOS_FILE **infile, int ncid, DimensionMap& dimens
 	if (debug_out) cout << "Process Global Attributes: \n";
 
 	std::string delimiter = "/";
-
 	std::map<std::string,char> processed_attrs;
 	std::map<std::string,int>  var_att_map;
 
@@ -207,18 +202,18 @@ void ProcessGlobalAttributes(ADIOS_FILE **infile, int ncid, DimensionMap& dimens
         {
             if (debug_out) cout << "    Attribute: " << infile[0]->attr_namelist[i] << std::endl;
             int asize;
-            char *adata;
+            char *adata = NULL;
             ADIOS_DATATYPES atype;
             adios_get_attr(infile[0], infile[0]->attr_namelist[i], &atype, &asize, (void**)&adata);
             nc_type piotype = PIOc_get_nctype_from_adios_type(atype);
             char *attname = infile[0]->attr_namelist[i]+strlen("pio_global/");
             if (debug_out) cout << "        define PIO attribute: " << attname << ""
-                    << "  type=" << piotype << std::endl;
+                    			<< "  type=" << piotype << std::endl;
             int len = 1;
             if (atype == adios_string)
                 len = strlen(adata);
             PIOc_put_att(ncid, PIO_GLOBAL, attname, piotype, len, adata);
-            free(adata);
+            if (adata) free(adata);
         } else {
 			std::string token = a.substr(0, a.find(delimiter));
 			if (token!="" && vars_map.find(token)==vars_map.end()) 
@@ -229,13 +224,13 @@ void ProcessGlobalAttributes(ADIOS_FILE **infile, int ncid, DimensionMap& dimens
            			string attname = token + "/__pio__/nctype";
 					processed_attrs[attname] = 1;
            			int asize;
-           			int *nctype;
+           			int *nctype = NULL;
            			ADIOS_DATATYPES atype;
            			adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&nctype);
 
             		attname = token + "/__pio__/ndims";
 					processed_attrs[attname] = 1;
-            		int *ndims;
+            		int *ndims = NULL;
             		adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&ndims);
 
             		char **dimnames = NULL;
@@ -253,14 +248,14 @@ void ProcessGlobalAttributes(ADIOS_FILE **infile, int ncid, DimensionMap& dimens
             		PIOc_def_var(ncid, token.c_str(), *nctype, *ndims, dimids, &varid);
 	           		var_att_map[token] = varid; 
 
-            		free(nctype);
-            		free(ndims);
-            		free(dimnames);
+            		if (nctype) free(nctype);
+            		if (ndims) free(ndims);
+            		if (dimnames) free(dimnames);
 				} else {
 					if (processed_attrs.find(a)==processed_attrs.end()) {
 						processed_attrs[a] = 1;
 						int asize;
-           				char *adata;
+           				char *adata = NULL;
            				ADIOS_DATATYPES atype;
            				adios_get_attr(infile[0], a.c_str(), &atype, &asize, (void**)&adata);
 						nc_type piotype = PIOc_get_nctype_from_adios_type(atype);
@@ -268,7 +263,7 @@ void ProcessGlobalAttributes(ADIOS_FILE **infile, int ncid, DimensionMap& dimens
         				int len = 1;
         				if (atype == adios_string) len = strlen(adata);
         				PIOc_put_att(ncid, var_att_map[token], attname, piotype, len, adata);
-        				free(adata);
+        				if (adata) free(adata);
 					}
 				}
 			}
@@ -302,58 +297,60 @@ Decomposition ProcessOneDecomposition(ADIOS_FILE **infile, int ncid, const char 
 		}
 	}
 
-    std::vector<PIO_Offset> d(nelems);
-    uint64_t offset = 0;
-    for (int i=1;i<=wfiles.size();i++) {
+	/* allocate +1 to prevent d.data() from returning NULL. Otherwise, read/write operations fail */
+	/* nelems may be 0, when some processes do not have any data */
+   	std::vector<PIO_Offset> d(nelems+1);  
+   	uint64_t offset = 0;
+   	for (int i=1;i<=wfiles.size();i++) {
 		ADIOS_VARINFO *vb = adios_inq_var(infile[i], varname);
 		if (vb) {
-       		adios_inq_var_blockinfo(infile[i], vb);
-	   		// Assuming all time steps have the same number of writer blocks	
-	   		for (int j=0;j<vb->nblocks[0];j++) {
-       		 	if (debug_out) cout << " rank " << mpirank << ": read decomp wb = " << j <<
-       		         	" start = " << offset <<
-       		         	" elems = " << vb->blockinfo[j].count[0] << endl;
+   			adios_inq_var_blockinfo(infile[i], vb);
+   			// Assuming all time steps have the same number of writer blocks	
+   			for (int j=0;j<vb->nblocks[0];j++) {
+   		 		if (debug_out) cout << " rank " << mpirank << ": read decomp wb = " << j <<
+   		       		  				" start = " << offset <<
+   		       		  				" elems = " << vb->blockinfo[j].count[0] << endl;
 				ADIOS_SELECTION *wbsel = adios_selection_writeblock(j);
-       		 	int ret = adios_schedule_read(infile[i], wbsel, varname, 0, 1, d.data()+offset);
-       		 	adios_perform_reads(infile[i], 1);
+   		 		int ret = adios_schedule_read(infile[i], wbsel, varname, 0, 1, d.data()+offset);
+   		 		adios_perform_reads(infile[i], 1);
 				offset += vb->blockinfo[j].count[0];
 				adios_selection_delete(wbsel);
-	   		}
-	   		adios_free_varinfo(vb);
+   			}
+   			adios_free_varinfo(vb);
 		}
 	}
 
-    string attname;
-    int asize;
-    int *piotype;
-    ADIOS_DATATYPES atype;
-    if (forced_type == NC_NAT) {
-        attname = string(varname) + "/piotype";
-        adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&piotype);
-    } else {
-        piotype = (int*) malloc(sizeof(int));
-        *piotype = forced_type;
-    }
-    attname = string(varname) + "/ndims";
-    int *decomp_ndims;
-    adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&decomp_ndims);
+   	string attname;
+   	int asize;
+   	int *piotype;
+   	ADIOS_DATATYPES atype;
+   	if (forced_type == NC_NAT) {
+   		 attname = string(varname) + "/piotype";
+   		 adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&piotype);
+   	} else {
+   		 piotype = (int*) malloc(sizeof(int));
+   		 *piotype = forced_type;
+   	}
+   	attname = string(varname) + "/ndims";
+   	int *decomp_ndims;
+   	adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&decomp_ndims);
 
-    int *decomp_dims;
-    attname = string(varname) + "/dimlen";
-    adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&decomp_dims);
-    TimerStop(read);
+   	int *decomp_dims;
+   	attname = string(varname) + "/dimlen";
+   	adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&decomp_dims);
+   	TimerStop(read);
 
-    TimerStart(write);
-    int ioid;
-    PIOc_InitDecomp(iosysid, *piotype, *decomp_ndims, decomp_dims, (PIO_Offset)nelems,
-            		d.data(), &ioid, NULL, NULL, NULL);
-    TimerStop(write);
+   	TimerStart(write);
+   	int ioid;
+   	PIOc_InitDecomp(iosysid, *piotype, *decomp_ndims, decomp_dims, (PIO_Offset)nelems,
+   		     		d.data(), &ioid, NULL, NULL, NULL);
+   	TimerStop(write);
 
 	int decomp_piotype = *piotype;
 
-    free(piotype);
-    free(decomp_ndims);
-    free(decomp_dims);
+   	free(piotype);
+   	free(decomp_ndims);
+   	free(decomp_dims);
 
     return Decomposition{ioid, decomp_piotype};
 }
@@ -379,9 +376,6 @@ DecompositionMap ProcessDecompositions(ADIOS_FILE **infile, int ncid, std::vecto
 Decomposition GetNewDecomposition(DecompositionMap& decompmap, string decompname,
         ADIOS_FILE **infile, int ncid, std::vector<int>& wfiles, int nctype, int iosysid, int mpirank, int nproc)
 {
-    // stringstream ss;
-    // ss << decompname << "_" << nctype;
-    // string key = ss.str();
 	char ss[256];
 	sprintf(ss,"%s_%d",decompname.c_str(),nctype);
 	string key(ss);
@@ -446,12 +440,12 @@ VariableMap ProcessVariableDefinitions(ADIOS_FILE **infile, int ncid, DimensionM
             	TimerStart(read);
             	string attname = string(infile[0]->var_namelist[i]) + "/__pio__/nctype";
             	int asize;
-            	int *nctype;
+            	int *nctype = NULL;
             	ADIOS_DATATYPES atype;
             	adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&nctype);
 
 	            attname = string(infile[0]->var_namelist[i]) + "/__pio__/ndims";
-	            int *ndims;
+	            int *ndims = NULL;
 	            adios_get_attr(infile[0], attname.c_str(), &atype, &asize, (void**)&ndims);
 
 	            char **dimnames = NULL;
@@ -464,11 +458,10 @@ VariableMap ProcessVariableDefinitions(ADIOS_FILE **infile, int ncid, DimensionM
 
 	                for (int d=0; d < *ndims; d++)
 	                {
-	                    //cout << "Dim " << d << " = " <<  dimnames[d] << endl;
 	                    dimids[d] = dimension_map[dimnames[d]].dimid;
 	                    if (dimension_map[dimnames[d]].dimvalue == PIO_UNLIMITED)
 	                    {
-                        timed = true;
+                        	timed = true;
 	                    }
 	                }
 	            }
@@ -482,9 +475,9 @@ VariableMap ProcessVariableDefinitions(ADIOS_FILE **infile, int ncid, DimensionM
 
 	            ProcessVarAttributes(infile, i, v, ncid, varid);
 
-	            free(nctype);
-	            free(ndims);
-	            free(dimnames);
+	            if (nctype) free(nctype);
+	            if (ndims) free(ndims);
+	            if (dimnames) free(dimnames);
 			}
         }
         FlushStdout_nm(comm);
@@ -638,7 +631,7 @@ int ConvertVariablePutVar(ADIOS_FILE **infile, std::vector<int> wfiles, int adio
 				return 1;
 			}
 			adios_selection_delete(wbsel);
-			free(buf);
+			if (buf) free(buf);
 		} else {
 			char temp_buf;
 			for (int d=0;d<vi->ndim;d++) {
@@ -681,12 +674,10 @@ int ConvertVariableTimedPutVar(ADIOS_FILE **infile, std::vector<int> wfiles, int
             TimerStart(write);
             start[0] = ts;
             count[0] = 1;
-            //cout << "DBG: " << infile->var_namelist[adios_varid] << " step " << ts
-            //     << " value = " << *(int*) vi->statistics->blocks->mins[ts] << endl;
             int ret = PIOc_put_vara(ncid, var.nc_varid, start, count, vi->statistics->blocks->mins[ts]);
             if (ret != PIO_NOERR)
-                cout << "ERROR in PIOc_put_var(), code = " << ret
-                << " at " << __func__ << ":" << __LINE__ << endl;
+				cout << "ERROR in PIOc_put_var(), code = " << ret
+					<< " at " << __func__ << ":" << __LINE__ << endl;
             TimerStop(write);
         }
     }
@@ -941,7 +932,9 @@ int ConvertVariableDarray(ADIOS_FILE **infile, int adios_varid, int ncid, Variab
 
 		/* Read local data for each file */
         int elemsize = adios_type_size(vi->type,NULL);
-        std::vector<char> d(nelems * elemsize);
+		/* allocate +1 to prevent d.data() from returning NULL. Otherwise, read/write operations fail */
+		/* nelems may be 0, when some processes do not have any data */
+        std::vector<char> d((nelems+1) * elemsize);
         uint64_t offset = 0;
 		for (int i=1;i<=wfiles.size();i++) {
             ADIOS_VARINFO *vb = adios_inq_var(infile[i], varname);


### PR DESCRIPTION
These patches (provided by Tahsin Kurc) are picked from
adios_support branch in ornladios repo.

[Adding code to handle PIO_NOCLOBBER for ADIOS IO type]
When we create a file of ADIOS IO type, if the specified file
already exists and PIO_NOCLOBBER mode is used, an error code
PIO_EEXIST should be returned.

[Handling decompositions with holes for ADIOS IO type]
Some tests use "decomposition with holes". For example, all
even procs take all elements from the odd procs, while all
odd procs have 0 elements. ADIOS needs to handle this kind
of decomposition correctly in the adios2pio converter.

[Fixing an issue for PIOc_put_var with several parts]
PIOc_put_var may be called multiple times with different start
and count values for a variable. ADIOS should output/convert
data for each of those calls.

[Handling single element decomposition arrays]
Some tests deal with decomposition arrays that have only one
element. For example, even procs write out 2 elements while
odd procs write out 1 element. ADIOS needs to handle the case
correctly where maplen is 1.