### PR TITLE
Fix and simplify GCDblocksize()

### DIFF
--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -236,7 +236,14 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
             if(del_arr[i] != 1)
                 loc_arr[j++] = i;
 
-        blk_len[0] = loc_arr[0];
+        /* This is handled differently from the Fortran version in PIO1,
+         * since array index is 1-based in Fortran and 0-based in C.
+         * Original Fortran code: blk_len(1) = loc_arr(1)
+         * Converted C code (incorrect): blk_len[0] = loc_arr[0];
+         * Converted C code (correct): blk_len[0] = loc_arr[0] + 1;
+         * For example, if loc_arr[0] is 2, the first block actually
+         * has 3 elements with indices 0, 1 and 2. */
+        blk_len[0] = loc_arr[0] + 1;
         blklensum = blk_len[0];
         /* If numblks > 1 then numblks must be <= arrlen */
         for(int i = 1; i < numblks - 1; i++)

--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -149,13 +149,13 @@ void compute_one_dim(int gdim, int ioprocs, int rank, PIO_Offset *start,
 
 /**
  * Look for the largest block of data for io which can be expressed in
- * terms of start and count.
+ * terms of start and count (account for gaps).
  *
  * @param arrlen
  * @param arr_in
  * @returns the size of the block
  */
-PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
+PIO_Offset GCDblocksize_gaps(int arrlen, const PIO_Offset *arr_in)
 {
     int numblks = 0;  /* Number of blocks. */
     int numtimes = 0; /* Number of times adjacent arr_in elements differ by != 1. */
@@ -275,6 +275,64 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
 
     free(del_arr);
     del_arr = NULL;
+
+    return bsize;
+}
+
+/**
+ * Look for the largest block of data for io which can be expressed in
+ * terms of start and count (ignore gaps).
+ *
+ * @param arrlen
+ * @param arr_in
+ * @returns the size of the block
+ */
+PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
+{
+    /* Check inputs. */
+    pioassert(arrlen > 0 && arr_in && arr_in[0] >= 0, "invalid input", __FILE__, __LINE__);
+
+    /* If theres is only one contiguous block with length 1,
+     * the result must be 1 and we can return. */
+    if (arrlen == 1)
+        return 1;
+
+    /* We can use the array length as the initial value. 
+     * Suppose we have n contiguous blocks with lengths
+     * b1, b2, ..., bn, then gcd(b1, b2, ..., bn) =
+     * gcd(b1 + b2 + ... + bn, b1, b2, ..., bn) =
+     * gcd(arrlen, b1, b2, ..., bn) */
+    PIO_Offset bsize = arrlen;
+
+    /* The minimum length of a block is 1. */
+    PIO_Offset blk_len = 1;
+
+    for (int i = 0; i < arrlen - 1; i++)
+    {
+        pioassert(arr_in[i + 1] >= 0, "invalid input", __FILE__, __LINE__);
+
+        if ((arr_in[i + 1] - arr_in[i]) == 1)
+        {
+            /* Still in a contiguous block. */
+            blk_len++;
+        }
+        else
+        {
+            /* The end of a block has been reached. */
+            if (blk_len == 1)
+                return 1;
+
+            bsize = lgcd(bsize, blk_len);
+            if (bsize == 1)
+              return 1;
+
+            /* Continue to find next block. */
+            blk_len = 1;
+        }
+    }
+
+    /* Handle the last block. */
+    bsize = lgcd(bsize, blk_len);
 
     return bsize;
 }

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -572,15 +572,17 @@ int test_CalcStartandCount()
     return 0;
 }
 
-/* Test the GDCblocksize() function. */
-int run_GDCblocksize_tests(MPI_Comm test_comm)
+/* Test the GCDblocksize() function (ignoring gaps). */
+int run_GCDblocksize_tests(MPI_Comm test_comm)
 {
     {
         int arrlen = 1;
         PIO_Offset arr_in[1] = {0};
         PIO_Offset blocksize;
-        
+
         blocksize = GCDblocksize(arrlen, arr_in);
+        /* 1 block: [0]
+         * expected result: 1 */
         if (blocksize != 1)
             return ERR_WRONG;
     }
@@ -589,42 +591,232 @@ int run_GDCblocksize_tests(MPI_Comm test_comm)
         int arrlen = 4;
         PIO_Offset arr_in[4] = {0, 1, 2, 3};
         PIO_Offset blocksize;
-        
+
         blocksize = GCDblocksize(arrlen, arr_in);
+        /* 1 block: [0 ~ 3]
+         * expected result: 4 */
         if (blocksize != 4)
             return ERR_WRONG;
     }
-    
+
     {
         int arrlen = 4;
         PIO_Offset arr_in[4] = {0, 2, 3, 4};
         PIO_Offset blocksize;
 
         blocksize = GCDblocksize(arrlen, arr_in);
+        /* 2 blocks: [0], [2 ~ 4]
+         * expected result: gcd(1, 3) = 1 */
         if (blocksize != 1)
             return ERR_WRONG;
     }
-    
+
     {
         int arrlen = 4;
         PIO_Offset arr_in[4] = {0, 1, 3, 4};
         PIO_Offset blocksize;
 
         blocksize = GCDblocksize(arrlen, arr_in);
-        if (blocksize != 1)
+        /* 2 blocks: [0 ~ 1], [3 ~ 4]
+         * expected result: gcd(2, 2) = 2 */
+        if (blocksize != 2)
             return ERR_WRONG;
     }
-    
+
     {
         int arrlen = 4;
         PIO_Offset arr_in[4] = {0, 1, 2, 4};
         PIO_Offset blocksize;
 
         blocksize = GCDblocksize(arrlen, arr_in);
+        /* 2 blocks: [0 ~ 2], [4]
+         * expected result: gcd(3, 1) = 1 */
         if (blocksize != 1)
             return ERR_WRONG;
     }
-    
+
+    {
+        int arrlen = 4;
+        PIO_Offset arr_in[4] = {0, 1, 4, 5};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 2 blocks: [0 ~ 1], [4 ~ 5]
+         * expected result: gcd(2, 2) = 2 */
+        if (blocksize != 2)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 4;
+        PIO_Offset arr_in[4] = {1, 2, 3, 4};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 1 block: [1 ~ 4]
+         * expected result: 4 */
+        if (blocksize != 4)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 4;
+        PIO_Offset arr_in[4] = {2, 3, 4, 5};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 1 block: [2 ~ 5]
+         * expected result: 4 */
+        if (blocksize != 4)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 4;
+        PIO_Offset arr_in[4] = {3, 2, 1, 0};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 4 blocks: [3], [2], [1], [0]
+         * expected result: gcd(1, 1, 1, 1) = 1 */
+        if (blocksize != 1)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 4;
+        PIO_Offset arr_in[4] = {2, 2, 2, 2};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 4 blocks: [2], [2], [2], [2]
+         * expected result: gcd(1, 1, 1, 1) = 1 */
+        if (blocksize != 1)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 6;
+        PIO_Offset arr_in[6] = {0, 1, 3, 2, 4, 5};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 4 blocks: [0 ~ 1], [3], [2], [4 ~ 5]
+         * expected result: gcd(2, 1, 1, 2) = 1 */
+        if (blocksize != 1)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 6;
+        PIO_Offset arr_in[6] = {0, 1, 4, 5, 2, 3};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 3 blocks: [0 ~ 1], [4 ~ 5], [2 ~ 3]
+         * expected result: gcd(2, 2, 2) = 2 */
+        if (blocksize != 2)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 6;
+        PIO_Offset arr_in[6] = {2, 3, 4, 5, 0, 1};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 2 blocks: [2 ~ 5], [0 ~ 1]
+         * expected result: gcd(4, 2) = 2 */
+        if (blocksize != 2)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 6;
+        PIO_Offset arr_in[6] = {3, 4, 5, 0, 1, 2};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 2 blocks: [3 ~ 5], [0 ~ 2]
+         * expected result: gcd(3, 3) = 3 */
+        if (blocksize != 3)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 6;
+        PIO_Offset arr_in[6] = {0, 1, 2, 3, 3, 4};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 2 blocks: [0 ~ 3], [3 ~ 4]
+         * expected result: gcd(4, 2) = 2 */
+        if (blocksize != 2)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 6;
+        PIO_Offset arr_in[6] = {0, 1, 1, 2, 2, 3};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 3 blocks: [0 ~ 1], [1 ~ 2], [2 ~ 3]
+         * expected result: gcd(2, 2, 2) = 2 */
+        if (blocksize != 2)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 12;
+        PIO_Offset arr_in[12] = {8, 9, 10, 11, 12, 13, 14, 15, 2, 3, 4, 5};
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 2 blocks: [8 ~ 15], [2 ~ 5]
+         * expected result: gcd(8, 4) = 4 */
+        if (blocksize != 4)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 2422;
+        PIO_Offset arr_in[2422];
+        for (int i = 0; i < 2422; i++)
+        {
+            if (i <= 2204)
+                arr_in[i] = i;
+            else
+                arr_in[i] = i + 2;
+        }
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 2 blocks: [0 ~ 2204] [2207 ~ 2423]
+         * expected result: gcd(2205, 217) = 7 */
+        if (blocksize != 7)
+            return ERR_WRONG;
+    }
+
+    {
+        int arrlen = 2422;
+        PIO_Offset arr_in[2422];
+        for (int i = 0; i < 2422; i++)
+        {
+            if (i <= 2203)
+                arr_in[i] = i;
+            else
+                arr_in[i] = i + 2;
+        }
+        PIO_Offset blocksize;
+
+        blocksize = GCDblocksize(arrlen, arr_in);
+        /* 2 blocks: [0 ~ 2203] [2206 ~ 2423]
+         * expected result: gcd(2204, 218) = 2 */
+        if (blocksize != 2)
+            return ERR_WRONG;
+    }
+
     return 0;
 }
 
@@ -656,7 +848,7 @@ int main(int argc, char **argv)
              return ret;
 
         printf("%d running tests for GCDblocksize()\n", my_rank);
-        if ((ret = run_GDCblocksize_tests(test_comm)))
+        if ((ret = run_GCDblocksize_tests(test_comm)))
             return ret;
 
         printf("%d running spmd test code\n", my_rank);

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -652,24 +652,24 @@ int main(int argc, char **argv)
             return ret;
 
         printf("%d running tests for functions in pioc_sc.c\n", my_rank);
-        /* if ((ret = run_sc_tests(test_comm))) */
-        /*     return ret; */
+        if ((ret = run_sc_tests(test_comm)))
+             return ret;
 
-        /* printf("%d running tests for GCDblocksize()\n", my_rank); */
-        /* if ((ret = run_GDCblocksize_tests(test_comm))) */
-        /*     return ret; */
+        printf("%d running tests for GCDblocksize()\n", my_rank);
+        if ((ret = run_GDCblocksize_tests(test_comm)))
+            return ret;
 
-        /* printf("%d running spmd test code\n", my_rank); */
-        /* if ((ret = run_spmd_tests(test_comm))) */
-        /*     return ret; */
+        printf("%d running spmd test code\n", my_rank);
+        if ((ret = run_spmd_tests(test_comm)))
+            return ret;
         
-        /* printf("%d running CalcStartandCount test code\n", my_rank); */
-        /* if ((ret = test_CalcStartandCount())) */
-        /*     return ret; */
+        printf("%d running CalcStartandCount test code\n", my_rank);
+        if ((ret = test_CalcStartandCount()))
+            return ret;
 
-        /* printf("%d running list tests\n", my_rank); */
-        /* if ((ret = test_lists())) */
-        /*     return ret; */
+        printf("%d running list tests\n", my_rank);
+        if ((ret = test_lists()))
+            return ret;
 
         printf("%d running varlist tests\n", my_rank);
         if ((ret = test_varlists()))
@@ -683,17 +683,17 @@ int main(int argc, char **argv)
         if ((ret = test_varlists3()))
             return ret;
 
-        /* printf("%d running ceil2/pair tests\n", my_rank); */
-        /* if ((ret = test_ceil2_pair())) */
-        /*     return ret; */
+        printf("%d running ceil2/pair tests\n", my_rank);
+        if ((ret = test_ceil2_pair()))
+            return ret;
 
-        /* printf("%d running find_mpi_type tests\n", my_rank); */
-        /* if ((ret = test_find_mpi_type())) */
-        /*     return ret; */
+        printf("%d running find_mpi_type tests\n", my_rank);
+        if ((ret = test_find_mpi_type()))
+            return ret;
 
-        /* printf("%d running misc tests\n", my_rank); */
-        /* if ((ret = test_misc())) */
-        /*     return ret; */
+        printf("%d running misc tests\n", my_rank);
+        if ((ret = test_misc()))
+            return ret;
 
         /* Finalize PIO system. */
         if ((ret = PIOc_finalize(iosysid)))


### PR DESCRIPTION
Restore commented out test cases on GCDblocksize(), update
expected result of an existing test case (gaps are ignored), and
add more test cases to verify the correctness of GCDblocksize().

Fix a bug in GCDblocksize() that was first introduced when the
original Fortran version was converted to C code.

Rewrite GCDblocksize() as part of code refactoring. The new
version uses less temporary variables, loops and memory.

Fixes #127