### PR TITLE
Fix the inputs check in PIOc_Init_Intracomm()

### DIFF
--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -804,7 +804,11 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
         return check_mpi2(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     /* Check the inputs. */
-    if (!iosysidp || num_iotasks < 1 || num_iotasks * stride > num_comptasks)
+    if (!iosysidp ||
+        num_iotasks < 1 || num_iotasks > num_comptasks ||
+        stride < 1 ||
+        base < 0 || base >= num_comptasks ||
+        stride * (num_iotasks - 1) >= num_comptasks)
         return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_Init_Intracomm comp_comm = %d num_iotasks = %d stride = %d base = %d "

--- a/tests/cunit/test_iosystem2_simple.c
+++ b/tests/cunit/test_iosystem2_simple.c
@@ -77,9 +77,6 @@ int main(int argc, char **argv)
         printf("%d newcomm = %d even = %d new_size = %d\n", my_rank, newcomm, even, new_size);
 
         /* Check that some bad inputs are rejected. */
-        if (PIOc_Init_Intracomm(newcomm, new_size, STRIDE + 30, BASE, REARRANGER,
-                                &iosysid) != PIO_EINVAL)
-            return ERR_WRONG;
         if (PIOc_Init_Intracomm(newcomm, new_size, STRIDE, BASE, REARRANGER, NULL) != PIO_EINVAL)
             return ERR_WRONG;
 

--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -104,6 +104,12 @@ else ()
     ARGUMENTS --pio-tf-stride=2 --pio-tf-num-aggregators=2
     NUMPROCS 2
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+
+  add_mpi_test(init_finalize_4_proc_2iop_3str
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_init_finalize
+    ARGUMENTS --pio-tf-num-io-tasks=2 --pio-tf-stride=3
+    NUMPROCS 4
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 endif ()
 
 #===== pio_async_init_finalize =====


### PR DESCRIPTION
The existing inputs check in PIOc_Init_Intracomm() uses an
incorrect formula, which has caused 4 e3sm_developer tests
with valid inputs to fail on Cori.

Added a new unit test to reproduce this bug and updated the
inputs check to make it pass. The 4 e3sm_developer tests also
pass with this fix.

Also removed a wrong test that fails with the new inputs check.

Fixes #131