### PR TITLE
Import some patches for ADIOS IO type

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -734,6 +734,7 @@ typedef struct adios_var_desc_t
     /* to handle PIOc_setframe with different decompositions */
     int64_t decomp_varid;
     int64_t frame_varid;
+    int64_t fillval_varid;
 } adios_var_desc_t;
 
 /* Track attributes */

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -792,10 +792,8 @@ typedef struct file_desc_t
     /** Number of global attributes defined. Needed to support PIOc_inq_nattrs() */
     int num_gattrs;
 
-#ifdef _ADIOS_ALL_PROCS 
 	/* ADIOS: assume all procs are also IO tasks */
 	int adios_iomaster;
-#endif
 
 	/* Track attributes */
 	/** attribute information. Allow PIO_MAX_VARS for now. */

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -718,6 +718,8 @@ static int PIOc_write_darray_adios(
         av->decomp_varid = adios_define_var(file->adios_group, name_varid, "", adios_integer, "1","","");
         sprintf(name_varid,"frame_id/%s",av->name);
         av->frame_varid = adios_define_var(file->adios_group, name_varid, "", adios_integer, "1","","");
+        sprintf(name_varid,"fillval_id/%s",av->name);
+        av->fillval_varid = adios_define_var(file->adios_group, name_varid, "", atype, "1","","");
 
 #ifdef _ADIOS_ALL_PROCS
         if (file->adios_iomaster == MPI_ROOT)
@@ -762,7 +764,12 @@ static int PIOc_write_darray_adios(
 
     adios_write_byid(file->adios_fh, av->adios_varid, buf);
 
-    /* different decompositions at different frames */
+    /* different decompositions at different frames and fillvalue */
+    if (fillvalue!=NULL) {
+        adios_write_byid(file->adios_fh, av->fillval_varid, fillvalue);
+    } else {
+        ioid = -ioid;
+    }
     adios_write_byid(file->adios_fh, av->decomp_varid, &ioid);
     adios_write_byid(file->adios_fh, av->frame_varid, &(file->varlist[varid].record));
 

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -584,11 +584,8 @@ static void PIOc_write_decomp_adios(file_desc_t *file, int ioid)
         free(mapbuf);
     }
 
-#ifdef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
+    /* ADIOS: assume all procs are also IO tasks */
     if (file->adios_iomaster == MPI_ROOT)
-#else
-    if (file->iosystem->iomaster == MPI_ROOT)
-#endif
     {
         adios_define_attribute_byvalue(file->adios_group,"piotype",name,adios_integer,1,&iodesc->piotype);
         adios_define_attribute_byvalue(file->adios_group,"ndims",name,adios_integer,1,&iodesc->ndims);
@@ -721,11 +718,7 @@ static int PIOc_write_darray_adios(
         sprintf(name_varid,"fillval_id/%s",av->name);
         av->fillval_varid = adios_define_var(file->adios_group, name_varid, "", atype, "1","","");
 
-#ifdef _ADIOS_ALL_PROCS
         if (file->adios_iomaster == MPI_ROOT)
-#else
-        if (file->iosystem->iomaster == MPI_ROOT)
-#endif  /* _ADIOS_ALL_PROCS */
         { /* TAHSIN: Some of the codes were moved to pio_nc.c */
             char decompname[32];
             sprintf(decompname, "%d", ioid);
@@ -748,11 +741,7 @@ static int PIOc_write_darray_adios(
     {
 		buf = PIOc_convert_buffer_adios(file,iodesc,av,array,arraylen,&ierr);
 		if (ierr!=0) {
-#ifdef _ADIOS_ALL_PROCS
        		if (file->adios_iomaster == MPI_ROOT)
-#else
-            if (file->iosystem->iomaster == MPI_ROOT)
-#endif /* _ADIOS_ALL_PROCS */
                     LOG((2,"Darray '%s' decomp type is double but the target type is float. "
                             "ADIOS cannot do type conversion because memory could not be allocated."
                             "Therefore the data will be corrupt for this variable in the .bp output\n",

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -256,7 +256,6 @@ int PIOc_closefile(int ncid)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype==PIO_IOTYPE_ADIOS) {
             if (file->adios_fh != -1)
             {
@@ -307,7 +306,6 @@ int PIOc_closefile(int ncid)
             free(file->filename);
             ierr = 0;
 	}
-#endif /* _ADIOS_ALL_PROCS */
 #endif
 
     /* If this is an IO task, then call the netCDF function. */
@@ -334,60 +332,9 @@ int PIOc_closefile(int ncid)
             break;
 #endif
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
   	case PIO_IOTYPE_ADIOS: /* needed to avoid default case and error. */
   		ierr = 0;
   		break;
-#else
-        case PIO_IOTYPE_ADIOS:
-            if (file->adios_fh != -1)
-            {
-                LOG((2,"ADIOS close file %s\n", file->filename));
-                adios_define_attribute_byvalue(file->adios_group,"/__pio__/fillmode","",adios_integer,1,&file->fillmode);
-                ierr = adios_close(file->adios_fh);
-                file->adios_fh = -1;
-            }
-            if (file->adios_group != -1)
-            {
-                adios_free_group(file->adios_group);
-                file->adios_group = -1;
-            }
-            for (int i=0; i<file->num_dim_vars; i++)
-            {
-                free (file->dim_names[i]);
-                file->dim_names[i] = NULL;
-            }
-            file->num_dim_vars = 0;
-            for (int i=0; i<file->num_vars; i++)
-            {
-                free(file->adios_vars[i].name);
-                file->adios_vars[i].name = NULL;
-                free(file->adios_vars[i].gdimids);
-                file->adios_vars[i].gdimids = NULL;
-            }
-            file->num_vars = 0;
-
-			/* Track attributes */
-			for (int i=0; i<file->num_attrs; i++) {
-				free(file->adios_attrs[i].att_name);
-				file->adios_attrs[i].att_name = NULL;
-			}
-			file->num_attrs = 0;
-
-#define CONVERT_TEST
-#ifdef CONVERT_TEST /* TAHSIN -- comment out for large scale run */
-            /* Convert XXXX.nc.bp to XXXX.nc */
-            len = strlen(file->filename);
-            assert(len > 6 && len <= PIO_MAX_NAME);
-            strncpy(outfilename, file->filename, len - 3);
-            outfilename[len - 3] = '\0';
-            C_API_ConvertBPToNC(file->filename, outfilename, "pnetcdf", ios->io_comm);
-#endif /* CONVERT_TEST */
-
-            free(file->filename);
-            ierr = 0;
-            break;
-#endif /* _ADIOS_ALL_PROCS */
 #endif
         default:
             return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -134,7 +134,6 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
 			/*
@@ -189,7 +188,6 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                 adios_define_attribute_byvalue(file->adios_group, name, path, adios_type, 1, op);
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
 
     /* If this is an IO task, then call the netCDF function. */
@@ -226,65 +224,6 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             }
         }
 #endif /* _PNETCDF */
-
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-			/*
-			if (ios->io_rank==0) {
-				printf("ADIOS: PROCESSING GLOBAL VARIABLE: %s varid: %d ios->ioproc: %d rank: %d %d\n",
-					name,varid,ios->ioproc,ios->io_rank,ios->iomaster); fflush(stdout);
-			}
-			*/
-
-            LOG((2,"ADIOS define attribute %s, varid %d, type %d\n", name, varid, atttype));
-            enum ADIOS_DATATYPES adios_type = PIOc_get_adios_type(atttype);
-            char path[256];
-            if (varid != PIO_GLOBAL)
-            {
-                adios_var_desc_t * av = &(file->adios_vars[varid]);
-                strncpy(path, av->name, sizeof(path));
-                ++file->adios_vars[varid].nattrs;
-            }
-            else
-            {
-                strncpy(path,"pio_global", sizeof(path));
-                file->num_gattrs++;
-            }
-
-			/* Tack attributes */
-			int num_attrs = file->num_attrs;
-			if (num_attrs>=PIO_MAX_VARS) {
-				fprintf(stderr, "ERROR: Num of attributes exceeds maximum (%d).\n",PIO_MAX_VARS);
-				fflush(stderr);
-				return PIO_EMAXATTS;
-			}
-			file->adios_attrs[num_attrs].att_name = strdup(name);
-			file->adios_attrs[num_attrs].att_len = len;
-			file->adios_attrs[num_attrs].att_type = atttype;
-			file->adios_attrs[num_attrs].att_varid = varid;
-			file->adios_attrs[num_attrs].att_ncid = ncid;
-			file->adios_attrs[num_attrs].adios_type = adios_type;
-			file->num_attrs++;
-
-			/*
-			if (ios->io_rank==0) {
-				printf("ADIOS: ATTRIBUTE %d: %s %d\n",num_attrs,name,len);
-				fflush(stdout);
-			}
-			*/
-
-            //Workaround for adios 1.12.0, where adios_define_attribute_byvalue
-            //  throws an error on a string attribute of ""
-            if (adios_type == adios_string || atttype == NC_CHAR)
-                adios_define_attribute(file->adios_group, name, path, adios_string, op, NULL);
-            else
-                adios_define_attribute_byvalue(file->adios_group, name, path, adios_type, 1, op);
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
         {
@@ -1161,7 +1100,6 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             if (varid < 0 || varid >= file->num_vars)
@@ -1195,11 +1133,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
                 /* Only the IO master does the IO, so we are not really
                  * getting parallel IO here. */
-#ifdef _ADIOS_ALL_PROCS
 				        if (file->adios_iomaster == MPI_ROOT)
-#else
-                if (ios->iomaster == MPI_ROOT)
-#endif /* _ADIOS_ALL_PROCS */
                 {
                     if (av->adios_varid == 0)
                     {
@@ -1216,11 +1150,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
                 /* Only the IO master does the IO, so we are not really
                  * getting parallel IO here. */
-#ifdef _ADIOS_ALL_PROCS
 				        if (file->adios_iomaster == MPI_ROOT)
-#else
-                if (ios->iomaster == MPI_ROOT)
-#endif /* _ADIOS_ALL_PROCS */
                 {
                     if (av->adios_varid == 0)
                     {
@@ -1297,18 +1227,13 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 adios_define_attribute_byvalue(file->adios_group,"__pio__/dims",av->name,adios_string_array,av->ndims,dimnames);
             }
 
-#ifdef _ADIOS_ALL_PROCS
 			      if (file->adios_iomaster == MPI_ROOT)
-#else
-            if (ios->iomaster == MPI_ROOT)
-#endif /* _ADIOS_ALL_PROCS */
             {
                 adios_define_attribute_byvalue(file->adios_group,"__pio__/ndims",av->name,adios_integer,1,&av->ndims);
                 adios_define_attribute_byvalue(file->adios_group,"__pio__/nctype",av->name,adios_integer,1,&av->nc_type);
                 adios_define_attribute(file->adios_group, "__pio__/ncop", av->name, adios_string, "put_var", NULL);
             }
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
 
     /* If this is an IO task, then call the netCDF function. */
@@ -1434,140 +1359,6 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             } /* endif ndims == 0 */
         }
 #endif /* _PNETCDF */
-
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            if (varid < 0 || varid >= file->num_vars)
-                return pio_err(file->iosystem, file, PIO_EBADID, __FILE__, __LINE__);
-            /* First we need to define the variable now that we know it's decomposition */
-            adios_var_desc_t * av = &(file->adios_vars[varid]);
-
-            /* Write ADIOS with memory type since ADIOS does not do conversions.
-             * Add an attribute describing the target output type (defined type).
-             */
-            if (xtype == NC_NAT)
-                xtype = vartype;
-
-            if (xtype == PIO_LONG_INTERNAL)
-            {
-                int typesize = sizeof(long int);
-                if (typesize == 4)
-                    xtype = PIO_INT;
-                else
-                    xtype = PIO_INT64;
-            }
-            if (xtype != vartype)
-                av->adios_type = PIOc_get_adios_type(xtype);
-
-            /* Scalars have to be handled differently. */
-            if (av->ndims == 0)
-            {
-                /* This is a scalar var. */
-                /*printf("ADIOS writing scalar '%s' varid = %d\n", av->name, varid);*/
-                pioassert(!start && !count && !stride, "expected NULLs", __FILE__, __LINE__);
-
-                /* Only the IO master does the IO, so we are not really
-                 * getting parallel IO here. */
-                if (ios->iomaster == MPI_ROOT)
-                {
-                    if (av->adios_varid == 0)
-                    {
-                        av->adios_varid = adios_define_var(file->adios_group, av->name, "", av->adios_type,
-                                "","","");
-                    }
-                    adios_write_byid(file->adios_fh, av->adios_varid, buf);
-                }
-            }
-            else if (av->ndims == 1 && file->dim_values[av->gdimids[0]] == PIO_UNLIMITED)
-            {
-                /* This is a scalar variable over time */
-                /*printf("ADIOS writing scalar '%s' over time varid = %d\n", av->name, varid);*/
-
-                /* Only the IO master does the IO, so we are not really
-                 * getting parallel IO here. */
-                if (ios->iomaster == MPI_ROOT)
-                {
-                    if (av->adios_varid == 0)
-                    {
-                        av->adios_varid = adios_define_var(file->adios_group, av->name, "", av->adios_type,
-                            "","","");
-                    }
-                    adios_write_byid(file->adios_fh, av->adios_varid, buf);
-                    char* dimnames[6];
-                    for (int i = 0; i < av->ndims; i++)
-                    {
-                        dimnames[i] = file->dim_names[av->gdimids[i]];
-                    }
-                    adios_define_attribute_byvalue(file->adios_group,"__pio__/dims",av->name,adios_string_array,av->ndims,dimnames);
-                }
-            }
-            else
-            {
-                /* This is not a scalar var. */
-                if (stride_present)
-                {
-                    LOG((2,"ADIOS does not support striding %s:%s\n"
-                            "Variable %s will be corrupted in the output\n"
-                            , __FILE__, __func__, av->name));
-                }
-                int d_start = 0;
-                if (file->dim_values[av->gdimids[0]] == PIO_UNLIMITED)
-                {
-                    d_start = 1; // omit the unlimited time dimension from the adios variable definition
-                }
-                char ldims[32],gdims[256],offs[256],tmp[256];
-                ldims[0] = '\0';
-                for (int d=d_start; d < av->ndims; d++)
-                {
-                    sprintf(tmp,"%lld", count[d]);
-                    strcat(ldims,tmp);
-                    if (d < av->ndims-1)
-                        strcat(ldims,",");
-                }
-                gdims[0] = '\0';
-                for (int d=d_start; d < av->ndims; d++)
-                {
-                    char dimname[128];
-                    snprintf(dimname, sizeof(dimname), "/__pio__/dim/%s", file->dim_names[av->gdimids[d]]);
-                    strcat(gdims,dimname);
-                    if (d < av->ndims-1)
-                        strcat(gdims,",");
-                }
-                offs[0] = '\0';
-                for (int d=d_start; d < av->ndims; d++)
-                {
-                    sprintf(tmp,"%lld", start[d]);
-                    strcat(offs,tmp);
-                    if (d < av->ndims-1)
-                        strcat(offs,",");
-                }
-                if (av->adios_varid == 0)
-                {
-                    /*printf("ADIOS variable %s on io rank %d define gdims=\"%s\", ldims=\"%s\", offsets=\"%s\"\n",
-                            av->name, ios->io_rank, gdims, ldims, offs);*/
-                    av->adios_varid = adios_define_var(file->adios_group, av->name, "", av->adios_type, ldims,gdims,offs);
-                }
-                adios_write_byid(file->adios_fh, av->adios_varid, buf);
-                char* dimnames[6];
-                /* record the NC dimensions in an attribute, including the unlimited dimension */
-                for (int i = 0; i < av->ndims; i++)
-                {
-                    dimnames[i] = file->dim_names[av->gdimids[i]];
-                }
-                adios_define_attribute_byvalue(file->adios_group,"__pio__/dims",av->name,adios_string_array,av->ndims,dimnames);
-            }
-
-            if (ios->iomaster == MPI_ROOT)
-            {
-                adios_define_attribute_byvalue(file->adios_group,"__pio__/ndims",av->name,adios_integer,1,&av->ndims);
-                adios_define_attribute_byvalue(file->adios_group,"__pio__/nctype",av->name,adios_integer,1,&av->nc_type);
-                adios_define_attribute(file->adios_group, "__pio__/ncop", av->name, adios_string, "put_var", NULL);
-            }
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
         {

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -89,7 +89,6 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             if (ndimsp) *ndimsp = file->num_dim_vars;
@@ -106,7 +105,6 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
             }
             ierr = 0;
      }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
 
@@ -121,26 +119,6 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
                 LOG((2, "PIOc_inq returned from ncmpi_inq unlimdimid = %d", *unlimdimidp));
         }
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            if (ndimsp) *ndimsp = file->num_dim_vars;
-            if (nvarsp) *nvarsp = file->num_vars;
-            if (ngattsp) *ngattsp = file->num_gattrs;
-            if (unlimdimidp)
-            {
-                *unlimdimidp = -1;
-                for (int i=0; i < file->num_dim_vars; ++i)
-                {
-                    if (file->dim_values[i] == PIO_UNLIMITED)
-                        *unlimdimidp = i;
-                }
-            }
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif 
 
         if (file->iotype == PIO_IOTYPE_NETCDF && file->do_io)
         {
@@ -372,27 +350,16 @@ int PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
             }
         }
 #endif /* _NETCDF4 */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        else if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         LOG((2, "PIOc_inq_unlimdims netcdf call returned %d", ierr));
     }
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
          LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
          ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */ 
 #endif
 
     /* Broadcast and check the return code. */
@@ -472,7 +439,6 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             if (sizep)
@@ -483,7 +449,6 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
             }
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -493,20 +458,6 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = pioc_pnetcdf_inq_type(ncid, xtype, name, sizep);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            if (sizep)
-            {
-                enum ADIOS_DATATYPES atype = PIOc_get_adios_type(xtype);
-                int asize = adios_type_size(atype,NULL);
-                *sizep = (PIO_Offset) asize;
-            }
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_inq_type(file->fh, xtype, name, (size_t *)sizep);
         LOG((2, "PIOc_inq_type netcdf call returned %d", ierr));
@@ -586,13 +537,11 @@ int PIOc_inq_format(int ncid, int *formatp)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
          *formatp = 1;
          ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -603,13 +552,11 @@ int PIOc_inq_format(int ncid, int *formatp)
             ierr = ncmpi_inq_format(file->fh, formatp);
 #endif /* _PNETCDF */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
         if (file->iotype == PIO_IOTYPE_ADIOS)
         {
             *formatp = 1;
             ierr = 0;
         }
-#endif /* _ADIOS_ALL_PROCS */
 #endif 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_inq_format(file->fh, formatp);
@@ -692,7 +639,6 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             if (0 <= dimid && dimid < file->num_dim_vars)
@@ -718,7 +664,6 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
                 ierr = PIO_EBADDIM;
             }
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
 
@@ -732,35 +677,6 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
             ierr = ncmpi_inq_dim(file->fh, dimid, name, lenp);;
         }
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            if (0 <= dimid && dimid < file->num_dim_vars)
-            {
-                if (name) strcpy(name, file->dim_names[dimid]);
-                if (lenp) *lenp = file->dim_values[dimid];
-                ierr = 0;
-            }
-            else
-            {
-                /*printf("WARNING: ncid %d: PIOc_inq_dim() invalid id=%d, only have 0..%d. " 
-                       "Dimensions defined: ",
-                       ncid, dimid, file->num_dim_vars);*/
-                for (int i=0; i < file->num_dim_vars; i++)
-                {
-                    printf("%s", file->dim_names[i]);
-                    if (i < file->num_dim_vars-1)
-                        printf(", ");
-                }
-                printf("\n");
-                if (name) name[0]='\0';
-                if (lenp) *lenp = 0;
-                ierr = PIO_EBADDIM;
-            }
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif 
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
         {
@@ -895,7 +811,6 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             ierr = PIO_EBADDIM;
@@ -921,7 +836,6 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
                 printf("\n");
             }
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* IO tasks call the netCDF functions. */
@@ -931,35 +845,6 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_dimid(file->fh, name, idp);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            ierr = PIO_EBADDIM;
-            for (int i=0; i < file->num_dim_vars; i++)
-            {
-                if (!strcmp(name, file->dim_names[i]))
-                {
-                    /*printf("WARNING: ncid %d: PIOc_inq_dimid(%s) found id=%d\n", ncid, name, i);*/
-                    *idp = i;
-                    ierr = PIO_NOERR;
-                    break;
-                }
-            }
-            if (ierr == PIO_EBADDIM) {
-                /*printf("WARNING: ncid %d: PIOc_inq_dimid(%s) did not find this dimension. "
-                        "Available dimensions: ", ncid, name);*/
-                for (int i=0; i < file->num_dim_vars; i++)
-                {
-                    printf("%s", file->dim_names[i]);
-                    if (i < file->num_dim_vars-1)
-                        printf(", ");
-                }
-                printf("\n");
-            }
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_inq_dimid(file->fh, name, idp);
     }
@@ -1060,7 +945,6 @@ int PIOc_inq_var(int ncid, int varid, char *name, int namelen, nc_type *xtypep, 
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             if (varid < file->num_vars)
@@ -1076,7 +960,6 @@ int PIOc_inq_var(int ncid, int varid, char *name, int namelen, nc_type *xtypep, 
             }
             else ierr = PIO_EBADID;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
 
 
@@ -1124,26 +1007,6 @@ int PIOc_inq_var(int ncid, int varid, char *name, int namelen, nc_type *xtypep, 
             free(tmp_dimidsp);
         }
 #endif /* _PNETCDF */
-
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            if (varid < file->num_vars)
-            {
-                if (name)    strcpy(name, file->adios_vars[varid].name);
-                if (xtypep)  *xtypep = file->adios_vars[varid].nc_type;
-                if (ndimsp)  *ndimsp = file->adios_vars[varid].ndims;
-                if (dimidsp)
-                    memcpy(dimidsp, file->adios_vars[varid].gdimids,
-                            file->adios_vars[varid].ndims * sizeof(int));
-                if (nattsp)  *nattsp = file->adios_vars[varid].nattrs;
-                ierr = 0;
-            }
-            else ierr = PIO_EBADID;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
         {
@@ -1429,7 +1292,6 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             ierr = PIO_ENOTVAR;
@@ -1444,7 +1306,6 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
                 }
             }
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
 
 
@@ -1455,24 +1316,6 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_varid(file->fh, name, varidp);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            ierr = PIO_ENOTVAR;
-            int i;
-            for (i=0; i < file->num_vars; i++)
-            {
-                if (!strcmp(name, file->adios_vars[i].name))
-                {
-                    *varidp = i;
-                    ierr = 0;
-                    break;
-                }
-            }
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_inq_varid(file->fh, name, varidp);
@@ -1605,7 +1448,6 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             /* LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__)); */
@@ -1622,7 +1464,6 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
 				}
 			}
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -1632,26 +1473,6 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_att(file->fh, varid, name, xtypep, lenp);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            /* LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__)); */
-			/* Track attributes */
-            ierr = PIO_ENOTATT;
-			for (int i=0;i<file->num_attrs;i++) {
-				if (!strcmp(name,file->adios_attrs[i].att_name) && 
-					file->adios_attrs[i].att_varid==varid &&
-					file->adios_attrs[i].att_ncid==ncid) {
-					ierr    = PIO_NOERR;
-					*xtypep = (nc_type) (file->adios_attrs[i].att_type);
-					*lenp   = (PIO_Offset) (file->adios_attrs[i].att_len);
-					i = file->num_attrs+1;
-				}
-			}
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
@@ -1769,13 +1590,11 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -1785,15 +1604,6 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_attname(file->fh, varid, attnum, name);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_inq_attname(file->fh, varid, attnum, name);
         LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
@@ -1886,13 +1696,11 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -1902,15 +1710,6 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_attid(file->fh, varid, name, idp);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_inq_attid(file->fh, varid, name, idp);
         LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
@@ -1994,13 +1793,11 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -2010,15 +1807,6 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_rename_dim(file->fh, dimid, name);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_rename_dim(file->fh, dimid, name);
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
@@ -2098,13 +1886,11 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -2114,15 +1900,6 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_rename_var(file->fh, varid, name);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_rename_var(file->fh, varid, name);
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
@@ -2209,13 +1986,11 @@ int PIOc_rename_att(int ncid, int varid, const char *name,
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -2225,15 +2000,6 @@ int PIOc_rename_att(int ncid, int varid, const char *name,
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_rename_att(file->fh, varid, name, newname);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_rename_att(file->fh, varid, name, newname);
     }
@@ -2312,13 +2078,11 @@ int PIOc_del_att(int ncid, int varid, const char *name)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -2328,15 +2092,6 @@ int PIOc_del_att(int ncid, int varid, const char *name)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_del_att(file->fh, varid, name);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_del_att(file->fh, varid, name);
     }
@@ -2410,14 +2165,12 @@ int PIOc_set_fill(int ncid, int fillmode, int *old_modep)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             if (old_modep) *old_modep = file->fillmode;
             file->fillmode = fillmode;
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -2430,16 +2183,6 @@ int PIOc_set_fill(int ncid, int fillmode, int *old_modep)
             ierr = ncmpi_set_fill(file->fh, fillmode, old_modep);
         }
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            if (old_modep) *old_modep = file->fillmode;
-            file->fillmode = fillmode;
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_set_fill(file->fh, fillmode, old_modep);
     }
@@ -2571,7 +2314,6 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             LOG((2,"ADIOS define dimension %s with size %llu, id = %d\n",
@@ -2586,7 +2328,6 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
             adios_write(file->adios_fh,dimname,&len);
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -2596,24 +2337,6 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_def_dim(file->fh, name, len, idp);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS define dimension %s with size %llu, id = %d\n",
-                    name, (unsigned long long)len, file->num_dim_vars));
-            char dimname[128];
-            snprintf(dimname, sizeof(dimname), "/__pio__/dim/%s", name);
-            adios_define_var(file->adios_group, dimname, "", adios_unsigned_long, "","","");
-            file->dim_names[file->num_dim_vars] = strdup(name);
-            file->dim_values[file->num_dim_vars] = len;
-            *idp = file->num_dim_vars;
-            ++file->num_dim_vars;
-            adios_write(file->adios_fh,dimname,&len);
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_def_dim(file->fh, name, (size_t)len, idp);
 
@@ -2746,7 +2469,6 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             LOG((2,"ADIOS pre-define variable %s (%d dimensions, type %d)\n", name, ndims, xtype));
@@ -2777,7 +2499,6 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
             }
             /* TAHSIN */
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* If this is an IO task, then call the netCDF function. */
@@ -2787,25 +2508,6 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_def_var(file->fh, name, xtype, ndims, dimidsp, varidp);
 #endif /* _PNETCDF */
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS pre-define variable %s (%d dimensions, type %d)\n", name, ndims, xtype));
-            file->adios_vars[file->num_vars].name = strdup(name);
-            file->adios_vars[file->num_vars].nc_type = xtype;
-            file->adios_vars[file->num_vars].adios_type = PIOc_get_adios_type(xtype);
-            file->adios_vars[file->num_vars].nattrs = 0;
-            file->adios_vars[file->num_vars].ndims = ndims;
-            file->adios_vars[file->num_vars].adios_varid = 0;
-            file->adios_vars[file->num_vars].gdimids = (int*) malloc(ndims*sizeof(int));
-            memcpy(file->adios_vars[file->num_vars].gdimids, dimidsp, ndims*sizeof(int));
-            *varidp = file->num_vars;
-            file->num_vars++;
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
             ierr = nc_def_var(file->fh, name, xtype, ndims, dimidsp, varidp);
 #ifdef _NETCDF4
@@ -3013,28 +2715,17 @@ int PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_value
             if (file->do_io)
                 ierr = nc_def_var_fill(file->fh, varid, fill_mode, fill_valuep);
 #endif
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         }
         LOG((2, "after def_var_fill ierr = %d", ierr));
     }
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
             LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
             ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
  
     /* Broadcast and check the return code. */
@@ -3202,27 +2893,16 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
                 ierr = nc_inq_var_fill(file->fh, varid, no_fill, fill_valuep);
 #endif /* _NETCDF */
         }
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-        {
-            LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
-            ierr = 0;
-        }
-#endif /* _ADIOS_ALL_PROCS */
-#endif
         LOG((2, "after call to inq_var_fill, ierr = %d", ierr));
     }
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
          LOG((2,"ADIOS missing %s:%s\n", __FILE__, __func__));
          ierr = 0;
     }
-#endif /* _ADIOS_ALL_PROCS */
 #endif
 
     /* Broadcast and check the return code. */

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2491,10 +2491,12 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
                 {
                     adios_define_attribute_byvalue(file->adios_group,"__pio__/ndims",av->name,adios_integer,1,&av->ndims);
                     adios_define_attribute_byvalue(file->adios_group,"__pio__/nctype",av->name,adios_integer,1,&av->nc_type);
-                    char* dimnames[6];
-                    for (int i = 0; i < av->ndims; i++)
-                        dimnames[i] = file->dim_names[av->gdimids[i]];
-                    adios_define_attribute_byvalue(file->adios_group,"__pio__/dims",av->name,adios_string_array,av->ndims,dimnames);
+                    if (av->ndims != 0) { /* If zero dimensions, do not write out __pio__/dims */
+                        char* dimnames[6];
+                        for (int i = 0; i < av->ndims; i++)
+                            dimnames[i] = file->dim_names[av->gdimids[i]];
+                        adios_define_attribute_byvalue(file->adios_group,"__pio__/dims",av->name,adios_string_array,av->ndims,dimnames);
+                    }
                 }
             }
             /* TAHSIN */

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1844,7 +1844,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 
 	/* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS
-#ifdef _ADIOS_ALL_PROCS
     if (file->iotype == PIO_IOTYPE_ADIOS) 
 	{
 		LOG((2, "Calling adios_open mode = %d", file->mode));
@@ -1907,7 +1906,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 		}
 	}
 #endif
-#endif
  
     /* If this task is in the IO component, do the IO. */
     if (ios->ioproc)
@@ -1961,54 +1959,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
             if (!ierr)
                 ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
             break;
-#endif
-
-#ifdef _ADIOS
-#ifndef _ADIOS_ALL_PROCS /* ADIOS: assume all procs are also IO tasks */
-        case PIO_IOTYPE_ADIOS:
-            LOG((2, "Calling adios_open mode = %d", file->mode));
-            /* Create a new ADIOS variable group, names the same as the filename for
-             * lack of better solution here */
-            int len = strlen(filename);
-            file->filename = malloc(len+3+3);
-            sprintf(file->filename, "%s.bp", filename);
-            adios_declare_group(&file->adios_group, file->filename, NULL, adios_stat_default);
-            int do_aggregate = (ios->num_comptasks != ios->num_iotasks);
-            if (do_aggregate)
-            {
-                sprintf(file->transport,"%s","MPI_AGGREGATE");
-                /* sprintf(file->params,"num_aggregators=%d,striping=0,have_metadata_file=0", ios->num_iotasks); */
-                sprintf(file->params,"num_aggregators=%d,random_offset=1,striping_count=1,have_metadata_file=0", 
-									ios->num_iotasks);
-            }
-            else
-            {
-                sprintf(file->transport,"%s","MPI_AGGREGATE");
-                /* sprintf(file->params,"num_aggregators=%d,striping=0,have_metadata_file=0", ios->num_comptasks/16); */
-                sprintf(file->params,"num_aggregators=%d,random_offset=1,striping_count=1,have_metadata_file=0", 
-									ios->num_comptasks/16);
-                /*sprintf(file->transport,"%s","POSIX");
-                file->params[0] = '\0';*/
-            }
-            /*adios_set_time_aggregation(file->adios_group,100000000,NULL);*/
-            adios_select_method(file->adios_group,file->transport,file->params,"");
-            /*adios_set_max_buffer_size(32);*/
-            ierr = adios_open(&file->adios_fh,file->filename,file->filename,"w", ios->io_comm);
-            memset(file->dim_names, 0, sizeof(file->dim_names));
-            file->num_dim_vars = 0;
-            file->num_vars = 0;
-            file->num_gattrs = 0;
-            file->fillmode = NC_NOFILL;
-            file->n_written_ioids = 0;
-
-			/* Track attributes */
-			file->num_attrs = 0;
-
-            int64_t vid = adios_define_var(file->adios_group, "/__pio__/info/nproc", "", adios_integer, "","","");
-            adios_write_byid(file->adios_fh, vid, &ios->num_iotasks);
-
-            break;
-#endif /* _ADIOS_ALL_PROCS */
 #endif
         }
     }

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -493,7 +493,10 @@ int put_var_nm(int ncid, int varid, int nctype, enum ADIOS_DATATYPES memtype, co
     switch(memtype)
     {
     case adios_byte:
-        ret = PIOc_put_var_schar(ncid, varid, (const signed char*)buf);
+		if (nctype==PIO_CHAR)
+			ret = PIOc_put_var_text(ncid, varid, (const char*)buf);
+		else  
+			ret = PIOc_put_var_schar(ncid, varid, (const signed char*)buf);
         break;
     case adios_short:
         ret = PIOc_put_var_short(ncid, varid, (const signed short*)buf);


### PR DESCRIPTION
These patches (provided by Tahsin Kurc) are picked from
adios_support branch in ornladios repo.

[Handling fill values for ADIOS IO type]
ADIOS needs to support fill values that are used to write
data with holes.

[Removing _ADIOS_ALL_PROCS macros (code cleanup)]
_ADIOS_ALL_PROCS should always be defined, so ADIOS
treats all the processes as I/O processes.

[Handling scalar char variables for ADIOS IO type]
Do not write out __pio__/dims when ndims is 0. Update
put_var_nm() for adios_byte type in the converter.