### PR TITLE
Add more supported Argonne Linux workstations for CTest

### DIFF
--- a/CTestScript.cmake
+++ b/CTestScript.cmake
@@ -72,6 +72,10 @@ elseif (HOSTNAME MATCHES "^hobart")
     set (HOSTNAME_ID "cgd")
 # Argonne Linux workstations
 elseif (HOSTNAME MATCHES "^compute001" OR
+        HOSTNAME MATCHES "^compute002" OR
+        HOSTNAME MATCHES "^compute003" OR
+        HOSTNAME MATCHES "^compute004" OR
+        HOSTNAME MATCHES "^compute005" OR
         HOSTNAME MATCHES "^thwomp" OR
         HOSTNAME MATCHES "^stomp" OR
         HOSTNAME MATCHES "^crush" OR


### PR DESCRIPTION
Some of these new workstations are used by CELS general use
Jenkins server. Without this change, some CDash builds failed
on MCS workstations like compute003.