### PR TITLE
Adding PIO_REDUCE_ERROR error handler

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -830,11 +830,15 @@ enum PIO_ERROR_HANDLERS
     /** Errors cause abort. */
     PIO_INTERNAL_ERROR = (-51),
 
-    /** Error codes are broadcast to all tasks. */
+    /** Error codes from io process with rank 0
+      * is broadcasted to all processes. */
     PIO_BCAST_ERROR = (-52),
 
+    /** Error codes are reduced across all processes. */
+    PIO_REDUCE_ERROR = (-53),
+
     /** Errors are returned to caller with no internal action. */
-    PIO_RETURN_ERROR = (-53)
+    PIO_RETURN_ERROR = (-54)
 };
 
 

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -309,7 +309,7 @@ int PIOc_set_iosystem_error_handling(int iosysid, int method, int *old_method)
 
     /* Check that valid error handler was provided. */
     if (method != PIO_INTERNAL_ERROR && method != PIO_BCAST_ERROR &&
-        method != PIO_RETURN_ERROR)
+        method != PIO_REDUCE_ERROR && method != PIO_RETURN_ERROR)
         return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* If using async, and not an IO task, then send parameters. */

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -33,7 +33,8 @@ module pio
        pio_nofill, pio_unlimited, pio_fill_int, pio_fill_double, pio_fill_float, &
 #endif
        pio_64bit_offset, pio_64bit_data, &
-       pio_internal_error, pio_bcast_error, pio_return_error, pio_default
+       pio_internal_error, pio_bcast_error, pio_reduce_error,&
+          pio_return_error, pio_default
 
   use piodarray, only : pio_read_darray, pio_write_darray, pio_set_buffer_size_limit  
 

--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -134,11 +134,13 @@ module pio_types
 !! The three types of error handling methods are:
 !!  - PIO_INTERNAL_ERROR  : abort on error from any task
 !!  - PIO_BCAST_ERROR     : broadcast an error from io_rank 0 to all tasks in comm
+!!  - PIO_REDUCE_ERROR     : Reduce error across all tasks in comm
 !!  - PIO_RETURN_ERROR    : do nothing - allow the user to handle it
 !<
   integer(i4), public, parameter :: PIO_INTERNAL_ERROR = -51
   integer(i4), public, parameter :: PIO_BCAST_ERROR = -52
-  integer(i4), public, parameter :: PIO_RETURN_ERROR = -53
+  integer(i4), public, parameter :: PIO_REDUCE_ERROR = -53
+  integer(i4), public, parameter :: PIO_RETURN_ERROR = -54
 
 !>
 !! @public

--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -263,13 +263,22 @@ add_dependencies (ncdf_fail pio_tutil)
 add_dependencies (tests ncdf_fail)
 
 if (PIO_USE_MPISERIAL)
-  add_test(NAME ncdf_fail
+  add_test(NAME ncdf_fail_bcast
     COMMAND ncdf_fail)
-  set_tests_properties(ncdf_fail
+  set_tests_properties(ncdf_fail_bcast
+    PROPERTIES TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+  add_test(NAME ncdf_fail_reduce
+    COMMAND ncdf_fail --pio-tf-err-handler=PIO_REDUCE_ERROR)
+  set_tests_properties(ncdf_fail_reduce
     PROPERTIES TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 else ()
-  add_mpi_test(ncdf_fail
+  add_mpi_test(ncdf_fail_bcast
     EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_fail
+    NUMPROCS 2
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+  add_mpi_test(ncdf_fail_reduce
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_fail
+    ARGUMENTS --pio-tf-err-handler=PIO_REDUCE_ERROR
     NUMPROCS 2
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 endif ()

--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -155,6 +155,7 @@ CONTAINS
     END IF
     IF ((pio_tf_err_handler_ /= PIO_INTERNAL_ERROR) .AND.&
         (pio_tf_err_handler_ /= PIO_BCAST_ERROR) .AND.&
+        (pio_tf_err_handler_ /= PIO_REDUCE_ERROR) .AND.&
         (pio_tf_err_handler_ /= PIO_RETURN_ERROR)) THEN
       PRINT *, "PIO_TF : Invalid error handler specified, resetting to PIO_BCAST_ERROR..."
       pio_tf_err_handler_ = PIO_BCAST_ERROR
@@ -1003,6 +1004,9 @@ CONTAINS
     ELSE IF((str == "PIO_BCAST_ERROR") .OR.&
         (str == "pio_bcast_error")) THEN
       Error_handler_from_str = PIO_BCAST_ERROR
+    ELSE IF((str == "PIO_REDUCE_ERROR") .OR.&
+        (str == "pio_reduce_error")) THEN
+      Error_handler_from_str = PIO_REDUCE_ERROR
     ELSE IF((str == "PIO_RETURN_ERROR") .OR.&
         (str == "pio_return_error")) THEN
       Error_handler_from_str = PIO_RETURN_ERROR


### PR DESCRIPTION
Adding a conservative error handler that detects errors
in any MPI process (logs error from each MPI process
and returns the minimum error code among all the 
MPI processes).

Fixes #107 