### PR TITLE
Performance Enhancement for PnetCDF IO type

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -37,6 +37,10 @@
 #define PIO_OFFSET MPI_OFFSET
 #define PIO_Offset MPI_Offset
 
+/** The start ID and maximum number of IDs for IO decompositions. */
+#define PIO_IODESC_START_ID 512
+#define PIO_IODESC_MAX_IDS 4096
+
 /** The maximum number of variables allowed in a netCDF file. */
 #define PIO_MAX_VARS_UB 8192
 #if NC_MAX_VARS > PIO_MAX_VARS_UB
@@ -780,8 +784,8 @@ typedef struct file_desc_t
     /* Bytes pending to be written out for this file */
     PIO_Offset wb_pend;
 
-    /** Data buffer for this file. */
-    void *iobuf;
+    /** Data buffer per IO decomposition for this file. */
+    void *iobuf[PIO_IODESC_MAX_IDS];
 
     /** Pointer to the next file_desc_t in the list of open files. */
     struct file_desc_t *next;

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -410,9 +410,9 @@ int PIOc_sync(int ncid)
             while (wmb)
             {
                 /* If there are any data arrays waiting in the
-                 * multibuffer, flush it. */
+                 * multibuffer, flush it to IO tasks. */
                 if (wmb->num_arrays > 0)
-                    flush_buffer(ncid, wmb, true);
+                    flush_buffer(ncid, wmb, false);
                 twmb = wmb;
                 wmb = wmb->next;
                 if (twmb == &file->buffer)

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -307,7 +307,6 @@ int pio_num_iosystem(int *niosysid)
  * need to be unique
  * @returns the ioid of the newly added iodesc.
  */
-#define PIO_IODESC_START_ID 512
 int pio_add_to_iodesc_list(io_desc_t *iodesc, MPI_Comm comm)
 {
     /* Using an arbitrary start id for iodesc ids helps

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1851,6 +1851,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 
     LOG((2, "file->do_io = %d ios->async = %d", file->do_io, ios->async));
 
+    for (int i = 0; i < PIO_IODESC_MAX_IDS; i++)
+        file->iobuf[i] = NULL;
+
     /* If async is in use, and this is not an IO task, bcast the
      * parameters. */
     if (ios->async)
@@ -2162,6 +2165,9 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
     if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
         ios->io_rank == 0)
         file->do_io = 1;
+
+    for (int i = 0; i < PIO_IODESC_MAX_IDS; i++)
+        file->iobuf[i] = NULL;
 
     /* If async is in use, bcast the parameters from compute to I/O procs. */
     if(ios->async)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2703,3 +2703,134 @@ const char *get_var_desc_str(int ncid, int varid, const char *desc_prefix)
 
     return file->varlist[varid].vdesc;
 }
+
+/* A ROMIO patch from PnetCDF's E3SM-IO benchmark program
+ * https://github.com/Parallel-NetCDF/E3SM-IO/blob/master/romio_patch.c */
+#if defined(MPICH_NUMVERSION) && (MPICH_NUMVERSION < 30300000)
+/*
+ *
+ *   Copyright (C) 2014 UChicgo/Argonne, LLC.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+/* utility function for creating large contiguous types: algorithim from BigMPI
+ * https://github.com/jeffhammond/BigMPI */
+
+static int type_create_contiguous_x(MPI_Count count, MPI_Datatype oldtype, MPI_Datatype * newtype)
+{
+    /* to make 'count' fit MPI-3 type processing routines (which take integer
+     * counts), we construct a type consisting of N INT_MAX chunks followed by
+     * a remainder.  e.g for a count of 4000000000 bytes you would end up with
+     * one 2147483647-byte chunk followed immediately by a 1852516353-byte
+     * chunk */
+    MPI_Datatype chunks, remainder;
+    MPI_Aint lb, extent, disps[2];
+    int blocklens[2];
+    MPI_Datatype types[2];
+
+    /* truly stupendously large counts will overflow an integer with this math,
+     * but that is a problem for a few decades from now.  Sorry, few decades
+     * from now! */
+    assert(count / INT_MAX == (int) (count / INT_MAX));
+    int c = (int) (count / INT_MAX);    /* OK to cast until 'count' is 256 bits */
+    int r = count % INT_MAX;
+
+    MPI_Type_vector(c, INT_MAX, INT_MAX, oldtype, &chunks);
+    MPI_Type_contiguous(r, oldtype, &remainder);
+
+    MPI_Type_get_extent(oldtype, &lb, &extent);
+
+    blocklens[0] = 1;
+    blocklens[1] = 1;
+    disps[0] = 0;
+    disps[1] = c * extent * INT_MAX;
+    types[0] = chunks;
+    types[1] = remainder;
+
+    MPI_Type_create_struct(2, blocklens, disps, types, newtype);
+
+    MPI_Type_free(&chunks);
+    MPI_Type_free(&remainder);
+
+    return MPI_SUCCESS;
+}
+
+/* like MPI_Type_create_hindexed, except array_of_lengths can be a larger datatype.
+ *
+ * Hindexed provides 'count' pairs of (displacement, length), but what if
+ * length is longer than an integer?  We will create 'count' types, using
+ * contig if length is small enough, or something more complex if not */
+
+int __wrap_ADIOI_Type_create_hindexed_x(int count,
+                                 const MPI_Count array_of_blocklengths[],
+                                 const MPI_Aint array_of_displacements[],
+                                 MPI_Datatype oldtype, MPI_Datatype * newtype)
+{
+    int i, ret;
+    MPI_Datatype *types;
+    int *blocklens;
+    int is_big = 0;
+
+    types = (MPI_Datatype*) malloc(count * sizeof(MPI_Datatype));
+    blocklens = (int*) malloc(count * sizeof(int));
+
+    /* squashing two loops into one.
+     * - Look in the array_of_blocklengths for any large values
+     * - convert MPI_Count items (if they are not too big) into int-sized items
+     * after this loop we will know if we can use MPI_type_hindexed or if we
+     * need a more complicated BigMPI-style struct-of-chunks.
+     *
+     * Why not use the struct-of-chunks in all cases?  HDF5 reported a bug,
+     * which I have not yet precicesly nailed down, but appears to have
+     * something to do with struct-of-chunks when the chunks are small */
+
+#ifdef USE_ORIGINAL_MPICH_3_2
+    for(i=0; i<count; i++) {
+        if (array_of_blocklengths[i] > INT_MAX) {
+            blocklens[i] = 1;
+            is_big=1;
+            type_create_contiguous_x(array_of_blocklengths[i], oldtype,  &(types[i]));
+        } else {
+            /* OK to cast: checked for "bigness" above */
+            blocklens[i] = (int)array_of_blocklengths[i];
+            MPI_Type_contiguous(blocklens[i], oldtype, &(types[i]));
+        }
+    }
+
+    if (is_big) {
+        ret = MPI_Type_create_struct(count, blocklens, array_of_displacements,
+                types, newtype);
+    } else {
+        ret = MPI_Type_create_hindexed(count, blocklens, array_of_displacements, oldtype, newtype);
+    }
+    for (i=0; i< count; i++)
+        MPI_Type_free(&(types[i]));
+#else
+    /* See https://github.com/pmodels/mpich/pull/3089 */
+    for (i = 0; i < count; i++) {
+        if (array_of_blocklengths[i] > INT_MAX) {
+            blocklens[i] = 1;
+            is_big = 1;
+            type_create_contiguous_x(array_of_blocklengths[i], oldtype, &(types[i]));
+        } else {
+            /* OK to cast: checked for "bigness" above */
+            blocklens[i] = (int) array_of_blocklengths[i];
+            types[i] = oldtype;
+        }
+    }
+
+    if (is_big) {
+        ret = MPI_Type_create_struct(count, blocklens, array_of_displacements, types, newtype);
+        for (i = 0; i < count; i++)
+            if (types[i] != oldtype)
+                MPI_Type_free(&(types[i]));
+    } else {
+        ret = MPI_Type_create_hindexed(count, blocklens, array_of_displacements, oldtype, newtype);
+    }
+#endif
+    free(types);
+    free(blocklens);
+
+    return ret;
+}
+#endif

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -1576,6 +1576,12 @@ int test_scalar(int iosysid, int num_flavors, int *flavor, int my_rank, int asyn
         if ((ret = PIOc_put_var_int(ncid, varid, &test_val)))
             ERR(ret);
 
+        /* Flush PnetCDF non-blocking write on the scalar value. */
+        if (flavor[fmt] == PIO_IOTYPE_PNETCDF) {
+            if ((ret = PIOc_sync(ncid)))
+                ERR(ret);
+        }
+
         /* Check the scalar var. */
         if ((ret = check_scalar_var(ncid, varid, flavor[fmt])))
             ERR(ret);


### PR DESCRIPTION
This PR applies some performance improvement tips to PnetCDF type:
* Override ROMIO function with more performant version
* Add some MPI-IO and PnetCDF hints to PIO
* Flush record variables and small variables together

These tips are from PnetCDF's E3SM-IO benchmark program, see
https://github.com/Parallel-NetCDF/E3SM-IO