### PR TITLE
Fix randomly failed C unit test test_iosystem2

### DIFF
--- a/tests/cunit/test_iosystem2.c
+++ b/tests/cunit/test_iosystem2.c
@@ -202,6 +202,8 @@ int main(int argc, char **argv)
                 ERR(ret);
             if ((ret = PIOc_closefile(ncid2)))
                 ERR(ret);
+
+            MPI_Barrier(test_comm);
         } /* next iotype */
         if ((ret = MPI_Comm_free(&newcomm)))
             MPIERR(ret);


### PR DESCRIPTION
test_iosystem2 fails occasionally on CDash for a long time.

In this test, an MPI_Barrier is necessary to make all ranks
start processing the next IO type at the same time.

Fixes #149