### PR TITLE
Removing MPI funcs not supported by mpi-serial

### DIFF
--- a/examples/c/darray_async.c
+++ b/examples/c/darray_async.c
@@ -237,8 +237,10 @@ data:
 	/* Initialize MPI. */
 	if ((ret = MPI_Init(&argc, &argv)))
 	    MPIERR(ret);
+        /*
 	if ((ret = MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
 	    MPIERR(ret);
+        */
 
 	/* Learn my rank and the total number of processors. */
 	if ((ret = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -229,8 +229,10 @@ data:
 	/* Initialize MPI. */
 	if ((ret = MPI_Init(&argc, &argv)))
 	    MPIERR(ret);
+        /*
 	if ((ret = MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
 	    MPIERR(ret);
+        */
 
 	/* Learn my rank and the total number of processors. */
 	if ((ret = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))

--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -288,8 +288,10 @@ int check_file(int ntasks, char *filename) {
 	/* Initialize MPI. */
 	if ((ret = MPI_Init(&argc, &argv)))
 	    MPIERR(ret);
+        /*
 	if ((ret = MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
 	    MPIERR(ret);
+        */
 
 	/* Learn my rank and the total number of processors. */
 	if ((ret = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))


### PR DESCRIPTION
Removing MPI_Comm_set_errhandler() from examples since its not
supported by mpi-serial. 

Fixes #151