### PR TITLE
Return soft failures in most PIO inquire functions

### DIFF
--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -125,7 +125,7 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
 
     if(ierr != PIO_NOERR){
         LOG((1, "nc*_inq failed, ierr = %d", ierr));
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        return ierr;
     }
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
@@ -320,8 +320,8 @@ int PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
     }
 
     if(ierr != PIO_NOERR){
-        LOG((1, "nc*_inq failed, ierr = %d", ierr));
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        LOG((1, "nc*_inq_unlimdims failed, ierr = %d", ierr));
+        return ierr;
     }
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
@@ -559,8 +559,8 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
     }
 
     if(ierr != PIO_NOERR){
-        LOG((1, "nc*_inq failed, ierr = %d", ierr));
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        LOG((1, "nc*_inq_dim failed, ierr = %d", ierr));
+        return ierr;
     }
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
@@ -688,8 +688,8 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
     }
 
     if(ierr != PIO_NOERR){
-        LOG((1, "nc*_inq failed, ierr = %d", ierr));
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        LOG((1, "nc*_inq_dimid failed, ierr = %d", ierr));
+        return ierr;
     }
 
     /* Broadcast results. */
@@ -859,8 +859,8 @@ int PIOc_inq_var(int ncid, int varid, char *name, int namelen, nc_type *xtypep, 
     }
 
     if(ierr != PIO_NOERR){
-        LOG((1, "nc*_inq failed, ierr = %d", ierr));
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        LOG((1, "nc*_inq_var failed, ierr = %d", ierr));
+        return ierr;
     }
 
     /* Broadcast the results for non-null pointers. */
@@ -1098,8 +1098,8 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
     }
 
     if(ierr != PIO_NOERR){
-        LOG((1, "nc*_inq failed, ierr = %d", ierr));
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        LOG((1, "nc*_inq_varid failed, ierr = %d", ierr));
+        return ierr;
     }
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
@@ -1224,8 +1224,8 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
     }
 
     if(ierr != PIO_NOERR){
-        LOG((1, "nc*_inq failed, ierr = %d", ierr));
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        LOG((1, "nc*_inq_att failed, ierr = %d", ierr));
+        return ierr;
     }
 
     /* Broadcast results. */
@@ -1340,8 +1340,8 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
     }
 
     if(ierr != PIO_NOERR){
-        LOG((1, "nc*_inq failed, ierr = %d", ierr));
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        LOG((1, "nc*_inq_attname failed, ierr = %d", ierr));
+        return ierr;
     }
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
@@ -1429,8 +1429,8 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
     }
 
     if(ierr != PIO_NOERR){
-        LOG((1, "nc*_inq failed, ierr = %d", ierr));
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        LOG((1, "nc*_inq_attid failed, ierr = %d", ierr));
+        return ierr;
     }
 
     /* Broadcast results. */

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -1333,12 +1333,8 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
         LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
     }
 
-    /* A failure to inquire is not fatal */
-    mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm);
-    if(mpierr != MPI_SUCCESS){
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-    }
-
+    /* Failure to inquire is fatal */
+    ierr = check_netcdf(NULL, file, ierr, __FILE__, __LINE__);
     if(ierr != PIO_NOERR){
         LOG((1, "nc*_inq_attname failed, ierr = %d", ierr));
         return ierr;


### PR DESCRIPTION
A failure during a PIO inquire function should not be considered
fatal in most cases. 

Certain inquire function failures are fatal, though. For example,
inquiring the name/size of a type (PIOc_inq_type()).
    
For a soft (non-fatal) failure, the error code is broadcast to
all processes and is directly returned to the user.
    
We no longer call pio_err() on a soft failure, as it aborts the
program if the error handler is set to PIO_INTERNAL_ERROR.

This change allows an ES3M case to continue if a failed PIO
inquiry is actually expected.