### PR TITLE
Switching from ready isends to regular isends

### DIFF
--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -308,13 +308,12 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
              * a major issue anymore, or is buggy. With PIO1 we have found that
              * although the code correctly posts receives before the irsends,
              * on some systems (software stacks) the code hangs. However the
-             * code works fine with isends. The USE_MPI_ISEND_FOR_FC macro should be
-             * used to choose between mpi_irsends and mpi_isends - the default
-             * is still mpi_irsend
+             * code works fine with isends. The _USE_MPI_RSEND macro should be
+             * used to use mpi_irsends, the default is mpi_isend
              */
             if (fc->hs && fc->isend)
             {
-#ifdef USE_MPI_ISEND_FOR_FC
+#ifndef _USE_MPI_RSEND
                 if ((mpierr = MPI_Isend(ptr, sendcounts[p], sendtypes[p], p, tag, comm,
                                         sndids + istep)))
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);


### PR DESCRIPTION
Switching the default MPI non blocking calls for data
rearrangement from "ready sends" to regular non blocking sends.

We have seen hangs on Titan and Cori with ready sends that
suggest bugs in the MPI library.

Fixes #155