### PR TITLE
Bug fixes for PIOc_openfile_retry() and PIOc_createfile_int()

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2416,7 +2416,8 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
 #endif
 
         default:
-            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
+            free(file);
+            return pio_err(ios, NULL, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
 
         /* If the caller requested a retry, and we failed to open a

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2292,8 +2292,10 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename)
         return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
-    if (*iotype < PIO_IOTYPE_PNETCDF || *iotype > PIO_IOTYPE_ADIOS)
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+
+    /* A valid iotype must be specified. */
+    if (!iotype_is_valid(*iotype))
+        return pio_err(ios, NULL, PIO_EBADIOTYPE, __FILE__, __LINE__);
 
     LOG((2, "PIOc_openfile_retry iosysid = %d iotype = %d filename = %s mode = %d retry = %d",
          iosysid, *iotype, filename, mode, retry));

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1879,7 +1879,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 
     /* A valid iotype must be specified. */
     if (!iotype_is_valid(*iotype))
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EBADIOTYPE, __FILE__, __LINE__);
 
     LOG((1, "PIOc_createfile iosysid = %d iotype = %d filename = %s mode = %d",
          iosysid, *iotype, filename, mode));

--- a/tests/cunit/test_iosystem2_simple.c
+++ b/tests/cunit/test_iosystem2_simple.c
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
             if (PIOc_openfile(iosysid_world, &ncid, &flavor[i], NULL, PIO_WRITE) != PIO_EINVAL)
                 return ERR_WRONG;
             int bad_iotype = flavor[i] + TEST_VAL_42;
-            if (PIOc_openfile(iosysid_world, &ncid, &bad_iotype, fn[0], PIO_WRITE) != PIO_EINVAL)
+            if (PIOc_openfile(iosysid_world, &ncid, &bad_iotype, fn[0], PIO_WRITE) != PIO_EBADIOTYPE)
                 return ERR_WRONG;
 
             /* Open the first file with world iosystem. */

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -1125,7 +1125,7 @@ int test_deletefile(int iosysid, int num_flavors, int *flavor, int my_rank)
         printf("%d testing delete for file %s with format %d...\n",
                my_rank, filename, flavor[fmt]);
         int bad_iotype = TEST_VAL_42;
-        if (PIOc_createfile(iosysid, &ncid, &bad_iotype, filename, PIO_CLOBBER) != PIO_EINVAL)
+        if (PIOc_createfile(iosysid, &ncid, &bad_iotype, filename, PIO_CLOBBER) != PIO_EBADIOTYPE)
             return ERR_WRONG;
         if ((ret = PIOc_createfile(iosysid, &ncid, &(flavor[fmt]), filename, PIO_CLOBBER)))
             ERR(ret);


### PR DESCRIPTION
PIOc_openfile_retry
{
In the switch statement on an IO type, when pio_err() returns
from the default case, we should free allocated memory for the
file info object.

The existing sanity check on an IO type is not based on build
configurations, and it also assumes specific enum type values.

This check should be performed with iotype_is_valid(), a helper
function that is also used by PIOc_createfile_int().
}

PIOc_createfile_int
{
Use PIO_EBADIOTYPE as the error code when iotype_is_valid()
indicates an invalid IO type for the build.

Also update C unit tests test_iosystem2_simple and test_pioc
to reflect this change.
}

Fixes #165