### PR TITLE
Support converting all ADIOS files in a directory to NetCDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,16 @@ configure_file (
   )
 
 #==============================================================================
+#  CHECK MIN VERSION OF COMPILERS REQD
+#==============================================================================
+# Regex is only available in GCC 4.9+ (> 4.8)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.8)
+    message (FATAL_ERROR "PIO requires GCC 4.9+ to build correctly")
+  endif()
+endif ()
+
+#==============================================================================
 #  SET CODE COVERAGE COMPILER FLAGS
 #==============================================================================
 

--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -21,7 +21,7 @@ elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
-SET(SRC adios2pio-nm.cxx)
+SET(SRC argparser.cxx adios2pio-nm.cxx)
 add_library(adios2pio-nm-lib adios2pio-nm-lib.cxx)
 include_directories(
   "${PROJECT_SOURCE_DIR}"   # to find foo/foo.h

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -1532,16 +1532,6 @@ void ConvertBPFile(string infilepath, string outfilename, int pio_iotype, int io
     }
 }
 
-void usage_nm(string prgname)
-{
-    cout << "Usage: " << prgname << " bp_file  nc_file  pio_io_type\n";
-    cout << "   bp file   :  data produced by PIO with ADIOS format\n";
-    cout << "   nc file   :  output file name after conversion\n";
-    cout << "   pio format:  output PIO_IO_TYPE. Supported parameters:\n";
-    cout << "                pnetcdf  netcdf  netcdf4c  netcdf4p   or:\n";
-    cout << "                   1       2        3         4\n";
-}
-
 enum PIO_IOTYPE GetIOType_nm(string t)
 {
     enum PIO_IOTYPE iotype = PIO_IOTYPE_NETCDF;

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -166,7 +166,7 @@ void ProcessGlobalFillmode(ADIOS_FILE **infile, int ncid)
     free(fillmode);
 }
 
-void ProcessVarAttributes(ADIOS_FILE **infile, int adios_varid, std::string varname,
+void ProcessVarAttributes(ADIOS_FILE **infile, int adios_varid, const std::string &varname,
                           int ncid, int nc_varid)
 {
     ADIOS_VARINFO *vi = adios_inq_var(infile[0], infile[0]->var_namelist[adios_varid]);
@@ -330,8 +330,10 @@ void ProcessGlobalAttributes(ADIOS_FILE **infile, int ncid, DimensionMap& dimens
     }
 }
 
-Decomposition ProcessOneDecomposition(ADIOS_FILE **infile, int ncid, const char *varname,
-                                      std::vector<int>& wfiles, int iosysid, int mpirank,
+Decomposition ProcessOneDecomposition(ADIOS_FILE **infile, int ncid,
+                                      const char *varname,
+                                      const std::vector<int>& wfiles,
+                                      int iosysid, int mpirank,
                                       int nproc, int forced_type = NC_NAT)
 {
     /* Read all decomposition blocks assigned to this process,
@@ -430,8 +432,10 @@ Decomposition ProcessOneDecomposition(ADIOS_FILE **infile, int ncid, const char 
     return Decomposition{ioid, decomp_piotype};
 }
 
-DecompositionMap ProcessDecompositions(ADIOS_FILE **infile, int ncid, std::vector<int>& wfiles,
-                                       int iosysid, MPI_Comm comm, int mpirank, int nproc)
+DecompositionMap ProcessDecompositions(ADIOS_FILE **infile, int ncid,
+                                        const std::vector<int>& wfiles,
+                                        int iosysid, MPI_Comm comm,
+                                        int mpirank, int nproc)
 {
     DecompositionMap decomp_map;
     for (int i = 0; i < infile[0]->nvars; i++)
@@ -453,9 +457,12 @@ DecompositionMap ProcessDecompositions(ADIOS_FILE **infile, int ncid, std::vecto
     return decomp_map;
 }
 
-Decomposition GetNewDecomposition(DecompositionMap& decompmap, string decompname,
-                                  ADIOS_FILE **infile, int ncid, std::vector<int>& wfiles,
-                                  int nctype, int iosysid, int mpirank, int nproc)
+Decomposition GetNewDecomposition(DecompositionMap& decompmap,
+                                  const string &decompname,
+                                  ADIOS_FILE **infile, int ncid,
+                                  const std::vector<int>& wfiles,
+                                  int nctype, int iosysid,
+                                  int mpirank, int nproc)
 {
     char ss[PIO_MAX_NAME];
     sprintf(ss, "%s_%d", decompname.c_str(), nctype);
@@ -644,7 +651,8 @@ int put_var_nm(int ncid, int varid, int nctype, enum ADIOS_DATATYPES memtype, co
 }
 
 int put_vara_nm(int ncid, int varid, int nctype, enum ADIOS_DATATYPES memtype,
-                PIO_Offset *start, PIO_Offset *count, const void* buf)
+                const PIO_Offset *start, const PIO_Offset *count,
+                const void* buf)
 {
     int ret = 0;
 
@@ -695,7 +703,8 @@ int put_vara_nm(int ncid, int varid, int nctype, enum ADIOS_DATATYPES memtype,
     return ret;
 }
 
-int ConvertVariablePutVar(ADIOS_FILE **infile, std::vector<int> wfiles, int adios_varid,
+int ConvertVariablePutVar(ADIOS_FILE **infile,
+                          const std::vector<int> &wfiles, int adios_varid,
                           int ncid, Variable& var, int mpirank, int nproc)
 {
     int ret = 0;
@@ -801,9 +810,11 @@ int ConvertVariablePutVar(ADIOS_FILE **infile, std::vector<int> wfiles, int adio
     return ret;
 }
 
-int ConvertVariableTimedPutVar(ADIOS_FILE **infile, std::vector<int> wfiles, int adios_varid,
-                               int ncid, Variable& var, int nblocks_per_step,
-                               MPI_Comm comm, int mpirank, int nproc)
+int ConvertVariableTimedPutVar(ADIOS_FILE **infile,
+                                const std::vector<int> &wfiles,
+                                int adios_varid,
+                                int ncid, Variable& var, int nblocks_per_step,
+                                MPI_Comm comm, int mpirank, int nproc)
 {
     int ret = 0;
 
@@ -1016,8 +1027,10 @@ int ConvertVariableTimedPutVar(ADIOS_FILE **infile, std::vector<int> wfiles, int
     return ret;
 }
 
-int ConvertVariableDarray(ADIOS_FILE **infile, int adios_varid, int ncid, Variable& var,
-                          std::vector<int>& wfiles, DecompositionMap& decomp_map,
+int ConvertVariableDarray(ADIOS_FILE **infile, int adios_varid,
+                          int ncid, Variable& var,
+                          const std::vector<int>& wfiles,
+                          DecompositionMap& decomp_map,
                           int nblocks_per_step, int iosysid,
                           MPI_Comm comm, int mpirank, int nproc)
 {
@@ -1229,7 +1242,7 @@ int ConvertVariableDarray(ADIOS_FILE **infile, int adios_varid, int ncid, Variab
  * assumes the file extensions are "infilename.bp.X"
  * where X is 0 to N-1.
  */
-int GetNumOfFiles(string infilename)
+int GetNumOfFiles(const string &infilename)
 {
     int file_count = 0;
     string foldername = infilename + ".dir/";
@@ -1253,7 +1266,7 @@ int GetNumOfFiles(string infilename)
     return file_count;
 }
 
-std::string ExtractFilename(std::string pathname)
+std::string ExtractFilename(const std::string &pathname)
 {
     size_t pos = pathname.find_last_of("/\\");
     if (pos == std::string::npos)
@@ -1266,7 +1279,7 @@ std::string ExtractFilename(std::string pathname)
     }
 }
 
-std::string ExtractPathname(std::string pathname)
+std::string ExtractPathname(const std::string &pathname)
 {
     size_t pos = pathname.find_last_of("/\\");
     if (pos == std::string::npos)
@@ -1279,8 +1292,9 @@ std::string ExtractPathname(std::string pathname)
     }
 }
 
-void ConvertBPFile(string infilepath, string outfilename, int pio_iotype, int iosysid,
-                   MPI_Comm comm, int mpirank, int nproc)
+void ConvertBPFile(const string &infilepath, const string &outfilename,
+                    int pio_iotype, int iosysid,
+                    MPI_Comm comm, int mpirank, int nproc)
 {
     ADIOS_FILE **infile = NULL;
     int num_infiles = 0;
@@ -1532,7 +1546,7 @@ void ConvertBPFile(string infilepath, string outfilename, int pio_iotype, int io
     }
 }
 
-enum PIO_IOTYPE GetIOType_nm(string t)
+enum PIO_IOTYPE GetIOType_nm(const string &t)
 {
     enum PIO_IOTYPE iotype = PIO_IOTYPE_NETCDF;
     if (t == "pnetcdf" || t == "PNETCDF" || t == "1")
@@ -1559,7 +1573,8 @@ enum PIO_IOTYPE GetIOType_nm(string t)
     return iotype;
 }
 
-int ConvertBPToNC(string infilepath, string outfilename, string piotype, MPI_Comm comm_in)
+int ConvertBPToNC(const string &infilepath, const string &outfilename,
+                  const string &piotype, MPI_Comm comm_in)
 {
     int ret = 0;
     int iosysid = 0;

--- a/tools/adios2pio-nm/adios2pio-nm-lib.h
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.h
@@ -7,7 +7,6 @@
 using namespace std;
 
 int ConvertBPToNC(string infilepath, string outfilename, string piotype, MPI_Comm comm_in);
-void usage_nm(string prgname);
 void SetDebugOutput(int val);
 
 #endif /* #ifndef _ADIOS2PIO_NM_LIB_H_ */

--- a/tools/adios2pio-nm/adios2pio-nm-lib.h
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.h
@@ -6,7 +6,9 @@
 
 using namespace std;
 
-int ConvertBPToNC(string infilepath, string outfilename, string piotype, MPI_Comm comm_in);
+int ConvertBPToNC(const string &infilepath,
+                  const string &outfilename,
+                  const string &piotype, MPI_Comm comm_in);
 void SetDebugOutput(int val);
 
 #endif /* #ifndef _ADIOS2PIO_NM_LIB_H_ */

--- a/tools/adios2pio-nm/adios2pio-nm-lib.h
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.h
@@ -9,6 +9,8 @@ using namespace std;
 int ConvertBPToNC(const string &infilepath,
                   const string &outfilename,
                   const string &piotype, MPI_Comm comm_in);
+int MConvertBPToNC(const string &bppdir, const string &piotype,
+                    MPI_Comm comm);
 void SetDebugOutput(int val);
 
 #endif /* #ifndef _ADIOS2PIO_NM_LIB_H_ */

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -4,15 +4,32 @@
 #endif
 #include <iostream>
 #include "adios2pio-nm-lib.h"
+#include "argparser.h"
 
-static void usage_nm(const string &prgname)
+static void init_user_options(adios2pio_utils::ArgParser &ap)
 {
-    cout << "Usage: " << prgname << " bp_file  nc_file  pio_io_type\n";
-    cout << "   bp file   :  data produced by PIO with ADIOS format\n";
-    cout << "   nc file   :  output file name after conversion\n";
-    cout << "   pio format:  output PIO_IO_TYPE. Supported parameters:\n";
-    cout << "                pnetcdf  netcdf  netcdf4c  netcdf4p   or:\n";
-    cout << "                   1       2        3         4\n";
+    ap.add_opt("bp-file", "data produced by PIO with ADIOS format")
+      .add_opt("nc-file", "output file name after conversion")
+      .add_opt("pio-format", "output PIO_IO_TYPE. Supported parameters: \"pnetcdf\",  \"netcdf\",  \"netcdf4c\",  \"netcdf4p\"");
+}
+
+static int get_user_options(
+              adios2pio_utils::ArgParser &ap,
+              int argc, char *argv[],
+              std::string &ifile, std::string &ofile, std::string &otype)
+{
+    ap.parse(argc, argv);
+    if (  !ap.has_arg("bp-file") ||
+          !ap.has_arg("nc-file") ||
+          !ap.has_arg("pio-format") )
+    {
+        ap.print_usage(std::cerr);
+        return 1;
+    }
+    ifile = ap.get_arg<std::string>("bp-file");
+    ofile = ap.get_arg<std::string>("nc-file");
+    otype = ap.get_arg<std::string>("pio-format");
+    return 0;
 }
 
 int main(int argc, char *argv[])
@@ -21,20 +38,21 @@ int main(int argc, char *argv[])
 
     MPI_Init(&argc, &argv);
 
-    int mpirank;
     MPI_Comm comm_in = MPI_COMM_WORLD;
-    MPI_Comm_rank(comm_in, &mpirank);
 
-    if (argc < 4)
+    adios2pio_utils::ArgParser ap(comm_in);
+
+    /* Init the standard user options for the tool */
+    init_user_options(ap);
+
+    /* Parse the user options */
+    string infilepath, outfilename, piotype;
+    ret = get_user_options(ap, argc, argv,
+                            infilepath, outfilename, piotype);
+    if (ret != 0)
     {
-        if (!mpirank)
-            usage_nm(argv[0]);
-        return 1;
+        return ret;
     }
-
-    string infilepath  = argv[1];
-    string outfilename = argv[2];
-    string piotype     = argv[3];
 
 #ifdef TIMING
     /* Initialize the GPTL timing library. */

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -5,7 +5,7 @@
 #include <iostream>
 #include "adios2pio-nm-lib.h"
 
-void usage_nm(string prgname)
+static void usage_nm(const string &prgname)
 {
     cout << "Usage: " << prgname << " bp_file  nc_file  pio_io_type\n";
     cout << "   bp file   :  data produced by PIO with ADIOS format\n";

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -12,7 +12,8 @@ static void init_user_options(adios2pio_utils::ArgParser &ap)
     ap.add_opt("bp-file", "data produced by PIO with ADIOS format")
       .add_opt("idir", "Directory containing data output from PIO (in ADIOS format)")
       .add_opt("nc-file", "output file name after conversion")
-      .add_opt("pio-format", "output PIO_IO_TYPE. Supported parameters: \"pnetcdf\",  \"netcdf\",  \"netcdf4c\",  \"netcdf4p\"");
+      .add_opt("pio-format", "output PIO_IO_TYPE. Supported parameters: \"pnetcdf\",  \"netcdf\",  \"netcdf4c\",  \"netcdf4p\"")
+      .add_opt("verbose", "Turn on verbose info messages");
 }
 
 static int get_user_options(
@@ -20,9 +21,12 @@ static int get_user_options(
               int argc, char *argv[],
               std::string &idir,
               std::string &ifile, std::string &ofile,
-              std::string &otype)
+              std::string &otype,
+              int &debug_lvl)
 {
     const std::string DEFAULT_PIO_FORMAT("pnetcdf");
+    debug_lvl = 0;
+
     ap.parse(argc, argv);
     if (!ap.has_arg("bp-file") && !ap.has_arg("idir"))
     {
@@ -67,6 +71,12 @@ static int get_user_options(
     {
         otype = DEFAULT_PIO_FORMAT;
     }
+
+    if (ap.has_arg("verbose"))
+    {
+        debug_lvl = 1;
+    }
+
     return 0;
 }
 
@@ -85,8 +95,11 @@ int main(int argc, char *argv[])
 
     /* Parse the user options */
     string idir, infilepath, outfilename, piotype;
+    int debug_lvl = 0;
     ret = get_user_options(ap, argc, argv,
-                            idir, infilepath, outfilename, piotype);
+                            idir, infilepath, outfilename,
+                            piotype, debug_lvl);
+
     if (ret != 0)
     {
         return ret;
@@ -98,7 +111,7 @@ int main(int argc, char *argv[])
         return ret;
 #endif
 
-    SetDebugOutput(0);
+    SetDebugOutput(debug_lvl);
     if (idir.size() == 0)
     {
         ret = ConvertBPToNC(infilepath, outfilename, piotype, comm_in);

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -2,7 +2,18 @@
 #ifdef TIMING
 #include <gptl.h>
 #endif
+#include <iostream>
 #include "adios2pio-nm-lib.h"
+
+void usage_nm(string prgname)
+{
+    cout << "Usage: " << prgname << " bp_file  nc_file  pio_io_type\n";
+    cout << "   bp file   :  data produced by PIO with ADIOS format\n";
+    cout << "   nc file   :  output file name after conversion\n";
+    cout << "   pio format:  output PIO_IO_TYPE. Supported parameters:\n";
+    cout << "                pnetcdf  netcdf  netcdf4c  netcdf4p   or:\n";
+    cout << "                   1       2        3         4\n";
+}
 
 int main(int argc, char *argv[])
 {

--- a/tools/adios2pio-nm/argparser.cxx
+++ b/tools/adios2pio-nm/argparser.cxx
@@ -10,7 +10,8 @@
 
 namespace adios2pio_utils{
 
-ArgParser::ArgParser(MPI_Comm comm):comm_(comm), is_root_(false)
+ArgParser::ArgParser(MPI_Comm comm):comm_(comm), is_root_(false),
+                                    printed_usage_(false) 
 {
     int rank;
     MPI_Comm_rank(comm, &rank);
@@ -79,10 +80,12 @@ bool ArgParser::has_arg(const std::string &opt) const
 
 void ArgParser::print_usage(std::ostream &ostr) const
 {
-    if (!is_root_)
+    if (printed_usage_ || !is_root_)
     {
         return;
     }
+    /* Ensure we only print usage once */
+    printed_usage_ = true;
     ostr << "Usage : " << prog_name_ << " [OPTIONAL ARGS] \n";
     ostr << "Optional Arguments :\n";
     for (std::map<std::string, std::string>::const_iterator

--- a/tools/adios2pio-nm/argparser.cxx
+++ b/tools/adios2pio-nm/argparser.cxx
@@ -109,7 +109,7 @@ void ArgParser::print_usage(std::ostream &ostr) const
     }
     /* Ensure we only print usage once */
     printed_usage_ = true;
-    ostr << "Usage : " << prog_name_ << " [OPTIONAL ARGS] \n";
+    ostr << "Usage : " << prog_name_ << " --[OPTIONAL ARG1 NAME]=[OPTIONAL ARG1 VALUE] --[OPTIONAL ARG2 NAME]=[OPTIONAL ARG2 VALUE] ... \n";
     ostr << "Optional Arguments :\n";
     for (std::map<std::string, std::string>::const_iterator
           citer = opts_map_.cbegin();

--- a/tools/adios2pio-nm/argparser.cxx
+++ b/tools/adios2pio-nm/argparser.cxx
@@ -56,19 +56,42 @@ void ArgParser::parse(int argc, char *argv[])
              */
             arg_map_[match.str(1)] = match.str(2);
         }
-        else if ((argvi == "--help") || (argvi == "-h"))
-        {
-            print_usage(std::cout);
-            return;
-        }
         else
         {
-            if (is_root_)
+            const std::string NOVAL_OPT_RGX_STR("--([^=]+)");
+            std::regex noval_opt_rgx(NOVAL_OPT_RGX_STR.c_str());
+            std::smatch noval_match;
+            /* The "--help" option is provided by default */
+            if ((argvi == "--help") || (argvi == "-h"))
             {
-                std::cerr << "Error: Unable to parse option : "
-                          << argvi << "\n";
+                print_usage(std::cout);
+                return;
             }
-            throw std::runtime_error("Invalid option");
+            else if (std::regex_search(argvi, noval_match, noval_opt_rgx) &&
+                (noval_match.size() == 2))
+            {
+                const std::string NOVAL_STR("noval");
+                /* No value arguments like "--verbose" */
+                if (opts_map_.count(noval_match.str(1)) != 1)
+                {
+                    if (is_root_)
+                    {
+                        std::cerr << "Error: Invalid option, "
+                                  << noval_match.str(1).c_str() << "\n";
+                    }
+                    throw std::runtime_error("Invalid option");
+                }
+                arg_map_[noval_match.str(1)] = NOVAL_STR;
+            }
+            else
+            {
+                if (is_root_)
+                {
+                    std::cerr << "Error: Unable to parse option : "
+                              << argvi << "\n";
+                }
+                throw std::runtime_error("Invalid option");
+            }
         }
     }
 }

--- a/tools/adios2pio-nm/argparser.cxx
+++ b/tools/adios2pio-nm/argparser.cxx
@@ -1,0 +1,75 @@
+#include "mpi.h"
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+#include <regex>
+#include <cassert>
+#include <stdexcept>
+#include "argparser.h"
+
+namespace adios2pio_utils{
+
+ArgParser &ArgParser::add_opt(const std::string &opt,
+                    const std::string &help_str)
+{
+    opts_map_[opt] = help_str;
+    return *this;
+}
+
+void ArgParser::parse(int argc, char *argv[])
+{
+    assert(argv);
+    prog_name_ = std::string(argv[0]);
+    const std::string OPT_RGX_STR("--([^=]+)=(.+)");
+    for (int i = 1; i < argc; i++)
+    {
+        std::regex opt_rgx(OPT_RGX_STR.c_str());
+        std::smatch match;
+        std::string argvi(argv[i]);
+        if (std::regex_search(argvi, match, opt_rgx) &&
+            (match.size() == 3))
+        {
+            if (opts_map_.count(match.str(1)) != 1)
+            {
+                std::cerr << "Error: Invalid option, "
+                          << match.str(1).c_str() << "\n";
+                throw std::runtime_error("Invalid option");
+            }
+            /* FIXME: No validation performed on the option value
+             * We could ask the user to specify option type when defining an 
+             * option
+             */
+            arg_map_[match.str(1)] = match.str(2);
+        }
+        else if ((argvi == "--help") || (argvi == "-h"))
+        {
+            print_usage(std::cout);
+            return;
+        }
+        else
+        {
+            std::cerr << "Error: Unable to parse option : " << argvi << "\n";
+            throw std::runtime_error("Invalid option");
+        }
+    }
+}
+
+bool ArgParser::has_arg(const std::string &opt) const
+{
+    return (arg_map_.count(opt) == 1);
+}
+
+void ArgParser::print_usage(std::ostream &ostr) const
+{
+    ostr << "Usage : " << prog_name_ << " [OPTIONAL ARGS] \n";
+    ostr << "Optional Arguments :\n";
+    for (std::map<std::string, std::string>::const_iterator
+          citer = opts_map_.cbegin();
+          citer != opts_map_.cend(); ++citer)
+    {
+        ostr << "--" << (*citer).first << ":\t" << (*citer).second << "\n";
+    }
+}
+
+} // namespace adios2pio_utils

--- a/tools/adios2pio-nm/argparser.h
+++ b/tools/adios2pio-nm/argparser.h
@@ -11,7 +11,7 @@ namespace adios2pio_utils{
 
 class ArgParser{
   public:
-    ArgParser() = default;
+    ArgParser(MPI_Comm comm);
     ArgParser &add_opt( const std::string &opt,
                         const std::string &help_str);
     void parse(int argc, char *argv[]);
@@ -23,6 +23,9 @@ class ArgParser{
     std::map<std::string, std::string> opts_map_;
     std::map<std::string, std::string> arg_map_;
     std::string prog_name_;
+    MPI_Comm comm_;
+    const int COMM_ROOT = 0;
+    bool is_root_;
 };
 
 template<typename T>

--- a/tools/adios2pio-nm/argparser.h
+++ b/tools/adios2pio-nm/argparser.h
@@ -1,0 +1,55 @@
+#include "mpi.h"
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+#include <regex>
+#include <cassert>
+#include <stdexcept>
+
+namespace adios2pio_utils{
+
+class ArgParser{
+  public:
+    ArgParser() = default;
+    ArgParser &add_opt( const std::string &opt,
+                        const std::string &help_str);
+    void parse(int argc, char *argv[]);
+    bool has_arg(const std::string &opt) const;
+    template<typename T>
+    T get_arg(const std::string &opt) const;
+    void print_usage(std::ostream &ostr) const;
+  private:
+    std::map<std::string, std::string> opts_map_;
+    std::map<std::string, std::string> arg_map_;
+    std::string prog_name_;
+};
+
+template<typename T>
+T ArgParser::get_arg(const std::string &opt) const
+{
+    throw std::runtime_error("Unsupported argument type");
+}
+
+template<>
+inline std::string ArgParser::get_arg<std::string>(const std::string &opt) const
+{
+    assert(arg_map_.count(opt) == 1);
+    return arg_map_.at(opt);
+}
+
+template<>
+inline int ArgParser::get_arg<int>(const std::string &opt) const
+{
+    assert(arg_map_.count(opt) == 1);
+    return std::stoi(arg_map_.at(opt));
+}
+
+template<>
+inline float ArgParser::get_arg<float>(const std::string &opt) const
+{
+    assert(arg_map_.count(opt) == 1);
+    return std::stof(arg_map_.at(opt));
+}
+
+} // namespace adios2pio_utils

--- a/tools/adios2pio-nm/argparser.h
+++ b/tools/adios2pio-nm/argparser.h
@@ -26,6 +26,7 @@ class ArgParser{
     MPI_Comm comm_;
     const int COMM_ROOT = 0;
     bool is_root_;
+    mutable bool printed_usage_;
 };
 
 template<typename T>


### PR DESCRIPTION
This PR includes,

* Changes in how command line options are processed in the
  conversion tool and changes in the command line option format
* New option to convert all ADIOS files in a directory to NetCDF and
  a new option to enable debug output.

Fixes #170 