### PR TITLE
Install ADIOS conversion tool and change name

### DIFF
--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -48,6 +48,9 @@ install (TARGETS adios2pio-nm-lib DESTINATION lib)
 # Include/Header File
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/adios2pio-nm-lib.h DESTINATION include)
 
+# Binary utilities
+install (TARGETS adios2pio-nm.exe DESTINATION bin)
+
 #===== NetCDF-C =====
 if (WITH_NETCDF)
 find_package (NetCDF "4.3.3" COMPONENTS C)

--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -39,8 +39,8 @@ target_compile_definitions (adios2pio-nm-lib
 target_compile_definitions (adios2pio-nm-lib
   PUBLIC ${CMAKE_C_COMPILER_DIRECTIVE})
 
-ADD_EXECUTABLE(adios2pio-nm ${SRC})
-TARGET_LINK_LIBRARIES(adios2pio-nm adios2pio-nm-lib pioc)
+ADD_EXECUTABLE(adios2pio-nm.exe ${SRC})
+TARGET_LINK_LIBRARIES(adios2pio-nm.exe adios2pio-nm-lib pioc)
 
 # Library
 install (TARGETS adios2pio-nm-lib DESTINATION lib)


### PR DESCRIPTION
This PR includes minor changes to,

* Add exe suffix to the ADIOS conversion tool
* Install the conversion tool

Fixes #173 