### PR TITLE
Further optimize the box rearrange create algorithm

### DIFF
--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -23,7 +23,7 @@
  * corresponding to this index.
  * @author Jim Edwards, Ed Hartnett
  */
-void idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
+inline void idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
                      PIO_Offset *dim_list)
 {
     /* Check inputs. */
@@ -193,7 +193,7 @@ PIO_Offset find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offs
  * @returns the local array index.
  * @author Jim Edwards
  */
-PIO_Offset coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO_Offset *count)
+inline PIO_Offset coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO_Offset *count)
 {
     PIO_Offset lindex = 0;
     PIO_Offset stride = 1;


### PR DESCRIPTION
Optimize the box rearrange create algorithm by reducing
the number of integer divisions used to convert a 1-D
index into a coordinate value.

For high-res E3SM cases using short PIO strides, this
optimization can greatly reduce the run time when BOX
rearranger is being used to read or write large-size
variables.

Also see PR #112 that optimized the same algorithm.

Fixes #179