### PR TITLE
Fix put_var test failures with internal timing

### DIFF
--- a/examples/c/put_var.c
+++ b/examples/c/put_var.c
@@ -232,9 +232,11 @@ int main(int argc, char* argv[])
     }
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     /* Initialize the GPTL timing library. */
     if ((ret = GPTLinitialize()))
         return ret;
+#endif
 #endif
 
     /* Initialize MPI. */
@@ -381,9 +383,11 @@ int main(int argc, char* argv[])
     MPI_Finalize();
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     /* Finalize the GPTL timing library. */
     if ((ret = GPTLfinalize()))
         return ret;
+#endif
 #endif
 
     if (verbose)


### PR DESCRIPTION
Ensure that put_var test does not explicitly initialize/finalize 
GPTL when internal timing (-DPIO_ENABLE_INTERNAL_TIMING)
is turned on.

Fixes #185 