### PR TITLE
Porting to Summit

### DIFF
--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -72,7 +72,6 @@ function (platform_name RETURN_VARIABLE)
         if (FQDN_SITENAME MATCHES "^.*summit[.]olcf")
             set (${RETURN_VARIABLE} "summit" PARENT_SCOPE)
         else()
-            message (WARNING "Unsupported system, ${FQDN_SITENAME}, using defaults")
             set (${RETURN_VARIABLE} "unknown" PARENT_SCOPE)
         endif ()
     

--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -68,8 +68,13 @@ function (platform_name RETURN_VARIABLE)
         set (${RETURN_VARIABLE} "olcf" PARENT_SCOPE)
         
     else ()
-
-        set (${RETURN_VARIABLE} "unknown" PARENT_SCOPE)
+        cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
+        if (FQDN_SITENAME MATCHES "^.*summit[.]olcf")
+            set (${RETURN_VARIABLE} "summit" PARENT_SCOPE)
+        else()
+            message (WARNING "Unsupported system, ${FQDN_SITENAME}, using defaults")
+            set (${RETURN_VARIABLE} "unknown" PARENT_SCOPE)
+        endif ()
     
     endif ()
 

--- a/cmake/mpiexec.summit
+++ b/cmake/mpiexec.summit
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Arguments:
+#
+#   $1  - Number of MPI Tasks
+#   $2+ - Executable and its arguments
+#
+
+# =============== Arguments ===================
+NTASKS=$1
+shift
+EXE=$@
+
+# =============== Constants ===================
+# Summit 1 node = 2 sockets = 42 physical cores = 168 hardware cores 
+# Summit 1 node has 6 GPUs, we use 0 GPUs, the default
+# The mpiexec command below 
+# --nrs ALL_HOSTS : Number of resource sets = number of hosts (number of nodes)
+#                   i.e., One resource set per node
+# --cpu_per_rs ALL_CPUS : Each resource set gets all CPUs on each node
+#                         i.e., Each resource set gets 42 CPUs
+# --latency-priority cpu-cpu : Ensures that CPU to CPU latency for CPUs within
+#                               a resource set is minimized. This setting is not
+#                               relevant since we only use 1 resource set/node
+# --launch_distribution packed : Consecutive MPI processes are assigned to a
+#                                 resource set till its filled up (pack MPI
+#                                 processes as tightly as possible in resource
+#                                 sets). Again not relevant since we only use
+#                                 1 resource set/node
+# --np $NTASKS : launches $NTASKS mpi processes
+
+# =============== MPIEXEC command =============
+#mpirun="jsrun --np $NTASKS --rs_per_host 1 $EXE"
+mpirun="jsrun --nrs ALL_HOSTS --cpu_per_rs ALL_CPUS --latency_priority cpu-cpu --launch_distribution packed --np $NTASKS $EXE"
+echo "Running: $mpirun"
+$mpirun

--- a/tests/general/pio_iodesc_tests.F90.in
+++ b/tests/general/pio_iodesc_tests.F90.in
@@ -314,7 +314,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_2d_two_iodescs
     PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
 
     do f=1,NFRAMES
-      if(mod(f,2) == 0) then
+      if(mod(INT(f),2) == 0) then
         is_even_frame = .true.
       else
         is_even_frame = .false.


### PR DESCRIPTION
This PR includes fixes for porting PIO2 to Summit (@OLCF),

* Minor fix to support IBM compiler
* CMake changes and mpiexec script for Summit