### PR TITLE
Increase the allowed len for cmd line arg

### DIFF
--- a/tests/performance/pioperformance_rearr.F90
+++ b/tests/performance/pioperformance_rearr.F90
@@ -352,7 +352,7 @@ contains
     type(pio_rearr_opt_t), intent(out) :: rearr_opts
     integer, intent(out) :: ierr
 
-    integer, parameter :: MAX_STDIN_ARG_LEN = 4096
+    integer, parameter :: MAX_STDIN_ARG_LEN = 8192
     character(len=MAX_PIO_TYPENAME_LEN) :: pio_typenames(MAX_PIO_TYPES)
     character(len=MAX_STDIN_ARG_LEN) :: argv
     integer :: i, nargs


### PR DESCRIPTION
Doubling (to 8K chars) the length of arguments specified by the
user via command line.
