### PR TITLE
Adding min version checks and removing CMake fortran utils repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,15 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif ()
 
 #==============================================================================
+#  MIN VERSION OF LIBRARIES REQD
+#==============================================================================
+set (MPE_MIN_VER_REQD "2.4.8")
+set (NETCDF_C_MIN_VER_REQD "4.3.3")
+set (NETCDF_FORTRAN_MIN_VER_REQD "4.3.3")
+set (PNETCDF_MIN_VER_REQD "1.8.1")
+set (ADIOS_MIN_VER_REQD "1.10.0")
+
+#==============================================================================
 #  SET CODE COVERAGE COMPILER FLAGS
 #==============================================================================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,25 +81,11 @@ endif()
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 #===== External modules =====
-if (NOT DEFINED USER_CMAKE_MODULE_PATH)
-  message (STATUS "Importing CMake_Fortran_utils")
-  execute_process(
-    COMMAND git clone https://github.com/CESM-Development/CMake_Fortran_utils
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET)
-  find_path (USER_CMAKE_MODULE_PATH
-    NAMES mpiexec.cmake
-    HINTS ${CMAKE_BINARY_DIR}/CMake_Fortran_utils)
-  if (USER_CMAKE_MODULE_PATH)
-    message (STATUS "Importing CMake_Fortran_utils - success")
-  else ()
-    message (FATAL_ERROR "Failed to import CMake_Fortran_utils")
-  endif ()
+if (DEFINED USER_CMAKE_MODULE_PATH)
+  set (USER_CMAKE_MODULE_PATH ${USER_CMAKE_MODULE_PATH}
+    CACHE STRING "Location of the CMake_Fortran_utils")
+  list (APPEND CMAKE_MODULE_PATH ${USER_CMAKE_MODULE_PATH})
 endif ()
-set (USER_CMAKE_MODULE_PATH ${USER_CMAKE_MODULE_PATH}
-  CACHE STRING "Location of the CMake_Fortran_utils")
-list (APPEND CMAKE_MODULE_PATH ${USER_CMAKE_MODULE_PATH})
 
 INCLUDE (CheckTypeSize)
 

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -17,6 +17,7 @@
 # If no components are specified, it assumes only C
 include (LibFind)
 include (LibCheck)
+include (FindPackageHandleStandardArgs)
 
 # Define NetCDF C Component
 define_package_component (NetCDF DEFAULT
@@ -63,6 +64,11 @@ foreach (NCDFcomp IN LISTS NetCDF_FIND_VALID_COMPONENTS)
                                NAME "netcdf_meta.h"
                                HINTS ${NetCDF_C_INCLUDE_DIRS}
                                MACRO_REGEX "NC_VERSION_")
+
+                find_package_handle_standard_args(NetCDF
+                  FOUND_VAR NetCDF_FOUND
+                  REQUIRED_VARS NetCDF_${NCDFcomp}_LIBRARY NetCDF_${NCDFcomp}_INCLUDE_DIR
+                  VERSION_VAR NetCDF_VERSION)
 
                 # Check for parallel support
                 check_macro (NetCDF_C_HAS_PARALLEL

--- a/cmake/FindPnetCDF.cmake
+++ b/cmake/FindPnetCDF.cmake
@@ -17,6 +17,7 @@
 # If no components are specified, it assumes only C
 include (LibFind)
 include (LibCheck)
+include (FindPackageHandleStandardArgs)
 
 # Define PnetCDF C Component
 define_package_component (PnetCDF DEFAULT
@@ -61,6 +62,10 @@ foreach (PNCDFcomp IN LISTS PnetCDF_FIND_VALID_COMPONENTS)
                            HINTS ${PnetCDF_${PNCDFcomp}_INCLUDE_DIR}
                            MACRO_REGEX "PNETCDF_VERSION_")
 
+            find_package_handle_standard_args(PnetCDF
+              FOUND_VAR PnetCDF_FOUND
+              REQUIRED_VARS PnetCDF_${PNCDFcomp}_LIBRARY PnetCDF_${PNCDFcomp}_INCLUDE_DIR
+              VERSION_VAR PnetCDF_VERSION)
         endif ()
             
     endif ()

--- a/cmake/TryCSizeOf.f90
+++ b/cmake/TryCSizeOf.f90
@@ -1,0 +1,6 @@
+       program trycsizeof
+         use iso_c_binding, only : c_sizeof
+         integer :: b
+         integer :: a(5)
+         b = c_sizeof(a(1))
+      end program trycsizeof

--- a/cmake/TryMPIIO.f90
+++ b/cmake/TryMPIIO.f90
@@ -1,0 +1,6 @@
+program mpicheck
+  include "mpif.h"
+  integer :: fh, ierr
+  
+  call mpi_file_open(mpi_comm_world, 'stupid.file',MPI_MODE_RDWR,MPI_INFO_NULL,fh,ierr)
+end program

--- a/cmake/TryMPIMod.f90
+++ b/cmake/TryMPIMod.f90
@@ -1,0 +1,4 @@
+program mpimodcheck
+  use mpi, only : MPI_ROOT, MPI_OFFSET
+  integer,parameter:: a = MPI_ROOT
+end program mpimodcheck

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -59,7 +59,7 @@ endif ()
 
 
 #===== MPE =====
-find_package (MPE "2.4.8" COMPONENTS C)
+find_package (MPE ${MPE_MIN_VER_REQD} COMPONENTS C)
 if (PIO_ENABLE_FORTRAN)
   if (MPE_C_FOUND)
     SET(SRC example2.c)

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -97,7 +97,7 @@ endif ()
 
 #===== NetCDF-C =====
 if (WITH_NETCDF)
-  find_package (NetCDF "4.3.3" COMPONENTS C)
+  find_package (NetCDF ${NETCDF_C_MIN_VER_REQD} COMPONENTS C)
 endif ()
 if (NetCDF_FOUND)
   target_include_directories (pioc
@@ -124,7 +124,7 @@ endif ()
 
 #===== PnetCDF-C =====
 if (WITH_PNETCDF)
-  find_package (PnetCDF "1.8.1" COMPONENTS C)
+  find_package (PnetCDF ${PNETCDF_MIN_VER_REQD} COMPONENTS C)
 endif ()
 if (PnetCDF_FOUND)
   target_include_directories (pioc
@@ -149,7 +149,7 @@ endif ()
 
 #===== ADIOS-C =====
 if (WITH_ADIOS)
-  find_package (ADIOS "1.10.0")
+  find_package (ADIOS ${ADIOS_MIN_VER_REQD})
 endif ()
 if (ADIOS_FOUND)
   target_include_directories (pioc

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -124,7 +124,7 @@ endif ()
 
 #===== PnetCDF-C =====
 if (WITH_PNETCDF)
-  find_package (PnetCDF "1.7.0" COMPONENTS C)
+  find_package (PnetCDF "1.8.1" COMPONENTS C)
 endif ()
 if (PnetCDF_FOUND)
   target_include_directories (pioc

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -99,7 +99,7 @@ endif ()
 if (WITH_NETCDF)
   find_package (NetCDF "4.3.3" COMPONENTS C)
 endif ()
-if (NetCDF_C_FOUND)
+if (NetCDF_FOUND)
   target_include_directories (pioc
     PUBLIC ${NetCDF_C_INCLUDE_DIRS})
   target_compile_definitions (pioc
@@ -126,7 +126,7 @@ endif ()
 if (WITH_PNETCDF)
   find_package (PnetCDF "1.7.0" COMPONENTS C)
 endif ()
-if (PnetCDF_C_FOUND)
+if (PnetCDF_FOUND)
   target_include_directories (pioc
     PUBLIC ${PnetCDF_C_INCLUDE_DIRS})
   target_compile_definitions (pioc

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -212,7 +212,7 @@ endif ()
 
 #===== PnetCDF =====
 if (WITH_PNETCDF)
-  find_package (PnetCDF "1.7.0" COMPONENTS Fortran)
+  find_package (PnetCDF "1.8.1" COMPONENTS Fortran)
 endif ()
 if (PnetCDF_FOUND)
   target_include_directories (piof

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -212,7 +212,7 @@ endif ()
 
 #===== PnetCDF =====
 if (WITH_PNETCDF)
-  find_package (PnetCDF "1.7.0" COMPONENTS Fortran REQUIRED)
+  find_package (PnetCDF "1.7.0" COMPONENTS Fortran)
 endif ()
 if (PnetCDF_Fortran_FOUND)
   target_include_directories (piof

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -194,7 +194,7 @@ endif ()
 if (WITH_NETCDF)
   find_package (NetCDF "4.3.3" COMPONENTS Fortran)
 endif ()
-if (NetCDF_Fortran_FOUND)
+if (NetCDF_FOUND)
   target_include_directories (piof
     PUBLIC ${NetCDF_Fortran_INCLUDE_DIRS})
   target_compile_definitions (piof
@@ -214,7 +214,7 @@ endif ()
 if (WITH_PNETCDF)
   find_package (PnetCDF "1.7.0" COMPONENTS Fortran)
 endif ()
-if (PnetCDF_Fortran_FOUND)
+if (PnetCDF_FOUND)
   target_include_directories (piof
     PUBLIC ${PnetCDF_Fortran_INCLUDE_DIRS})
   target_compile_definitions (piof

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -192,7 +192,7 @@ endif ()
 
 #===== NetCDF-Fortran =====
 if (WITH_NETCDF)
-  find_package (NetCDF "4.3.3" COMPONENTS Fortran)
+  find_package (NetCDF ${NETCDF_FORTRAN_MIN_VER_REQD} COMPONENTS Fortran)
 endif ()
 if (NetCDF_FOUND)
   target_include_directories (piof
@@ -212,7 +212,7 @@ endif ()
 
 #===== PnetCDF =====
 if (WITH_PNETCDF)
-  find_package (PnetCDF "1.8.1" COMPONENTS Fortran)
+  find_package (PnetCDF ${PNETCDF_MIN_VER_REQD} COMPONENTS Fortran)
 endif ()
 if (PnetCDF_FOUND)
   target_include_directories (piof

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -212,7 +212,7 @@ endif ()
 
 #===== PnetCDF =====
 if (WITH_PNETCDF)
-  find_package (PnetCDF "1.6" COMPONENTS Fortran REQUIRED)
+  find_package (PnetCDF "1.7.0" COMPONENTS Fortran REQUIRED)
 endif ()
 if (PnetCDF_Fortran_FOUND)
   target_include_directories (piof

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,7 +3,7 @@
 ###-------------------------------------------------------------------------###
 
 if (WITH_ADIOS)
-  find_package (ADIOS "1.10.0")
+  find_package (ADIOS ${ADIOS_MIN_VER_REQD})
   if (ADIOS_FOUND)
     ADD_SUBDIRECTORY(adios2pio-nm)
   endif (ADIOS_FOUND)

--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -80,7 +80,7 @@ endif ()
 
 #===== PnetCDF-C =====
 if (WITH_PNETCDF)
-  find_package (PnetCDF "1.7.0" COMPONENTS C)
+  find_package (PnetCDF "1.8.1" COMPONENTS C)
 endif ()
 if (PnetCDF_C_FOUND)
   target_include_directories (adios2pio-nm-lib

--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -53,7 +53,7 @@ install (TARGETS adios2pio-nm.exe DESTINATION bin)
 
 #===== NetCDF-C =====
 if (WITH_NETCDF)
-find_package (NetCDF "4.3.3" COMPONENTS C)
+find_package (NetCDF ${NETCDF_C_MIN_VER_REQD} COMPONENTS C)
 endif ()
 if (NetCDF_C_FOUND)
   target_include_directories (adios2pio-nm-lib
@@ -80,7 +80,7 @@ endif ()
 
 #===== PnetCDF-C =====
 if (WITH_PNETCDF)
-  find_package (PnetCDF "1.8.1" COMPONENTS C)
+  find_package (PnetCDF ${PNETCDF_MIN_VER_REQD} COMPONENTS C)
 endif ()
 if (PnetCDF_C_FOUND)
   target_include_directories (adios2pio-nm-lib
@@ -105,7 +105,7 @@ endif ()
 
 #===== ADIOS-C =====
 if (WITH_ADIOS)
-  find_package (ADIOS "1.10.0")
+  find_package (ADIOS ${ADIOS_MIN_VER_REQD})
 endif ()
 if (ADIOS_FOUND)
   target_include_directories (adios2pio-nm-lib


### PR DESCRIPTION
This PR includes changes to,

* Support minimum version checks for NetCDF and PnetCDF
* Remove explicit checkout and use of CMake_Fortran_utils 

Fixes #22 