### PR TITLE
Fix BGET usage

### DIFF
--- a/src/clib/bget.c
+++ b/src/clib/bget.c
@@ -677,44 +677,6 @@ static inline void pio_ubuf_free(void *ubuf)
 
 #endif /* PIO_USE_MALLOC */
 
-/* added for PIO so that a bpool can be freed and another allocated */
-void bpoolrelease()
-{
-    LOG((2, "bpoolrelease"));
-    freelist.bh.prevfree=0;
-    freelist.bh.bsize=0;
-    freelist.ql.flink=&freelist;
-    freelist.ql.blink=&freelist;
-    LOG((2, "bpoolrelease"));
-
-#ifdef BufStats
-    totalloc = 0;             /* Total space currently allocated */
-    numget = 0;
-    numrel = 0;   /* Number of bget() and brel() calls */
-#ifdef BECtl
-    numpblk = 0;              /* Number of pool blocks */
-    numpget = 0;
-    numprel = 0; /* Number of block gets and rels */
-    numdget = 0;
-    numdrel = 0; /* Number of direct gets and rels */
-#endif /* BECtl */
-#endif /* BufStats */
-    LOG((2, "bpoolrelease"));
-
-#ifdef BECtl
-/* Automatic expansion block management functions */
-    compfcn = NULL;
-    acqfcn = NULL;
-    relfcn = NULL;
-    exp_incr = 0;
-    pool_len = 0;
-#endif
-    LOG((2, "bpoolrelease"));
-
-}
-
-
-
 /*  BGET  --  Allocate a buffer.  */
 
 void *bget(bufsize requested_size)

--- a/src/clib/bget.h
+++ b/src/clib/bget.h
@@ -27,7 +27,6 @@ void    bstatse(bufsize *pool_incr, long *npool, long *npget,
 void    bufdump(void *buf);
 void    bpoold(void *pool, int dumpalloc, int dumpfree);
 int     bpoolv(void *pool);
-void bpoolrelease();
 void bfreespace(bufsize *maxfree, bufsize *totfree);
 
 #endif

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -19,9 +19,6 @@
 /* 10MB default limit. */
 PIO_Offset pio_buffer_size_limit = 10485760;
 
-/* Global buffer pool pointer. */
-void *CN_bpool = NULL;
-
 /* Maximum buffer usage. */
 PIO_Offset maxusage = 0;
 

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -37,6 +37,12 @@ void bpool_free(void *p)
   }
 }
 
+/* Handler for allocating more memory for the bget buffer pool */
+void *bpool_alloc(bufsize sz)
+{
+  void *p = malloc((size_t ) sz);
+  return p;
+}
 
 /**
  * Initialize the compute buffer to size pio_cnbuffer_limit.
@@ -65,7 +71,7 @@ int compute_buffer_init(iosystem_desc_t *ios)
         if (!CN_bpool)
             return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        bectl(NULL, malloc, bpool_free, pio_cnbuffer_limit);
+        bectl(NULL, bpool_alloc, bpool_free, pio_cnbuffer_limit);
     }
 #endif /* PIO_USE_MALLOC */
     LOG((2, "compute_buffer_init complete"));

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1718,7 +1718,7 @@ void free_cn_buffer_pool(iosystem_desc_t *ios)
     if (CN_bpool)
     {
         cn_buffer_report(ios, false);
-        bpoolrelease(CN_bpool);
+        bpoolrelease();
         LOG((2, "free_cn_buffer_pool done!"));
         free(CN_bpool);
         CN_bpool = NULL;

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1688,24 +1688,6 @@ void cn_buffer_report(iosystem_desc_t *ios, bool collective)
 }
 
 /**
- * Free the buffer pool. If malloc is used (that is, PIO_USE_MALLOC is
- * non zero), this function does nothing.
- *
- * @param ios pointer to the IO system structure.
- * @ingroup PIO_write_darray
- * @author Jim Edwards
- */
-void free_cn_buffer_pool(iosystem_desc_t *ios)
-{
-#if !PIO_USE_MALLOC
-    LOG((2, "free_cn_buffer_pool"));
-    cn_buffer_report(ios, false);
-    bpoolrelease();
-    LOG((2, "free_cn_buffer_pool done!"));
-#endif /* !PIO_USE_MALLOC */
-}
-
-/**
  * Flush the buffer.
  *
  * @param ncid identifies the netCDF file.

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -20,7 +20,7 @@
 extern PIO_Offset pio_buffer_size_limit;
 
 /* Initial size of compute buffer. */
-bufsize pio_cnbuffer_limit = 33554432;
+bufsize pio_cnbuffer_limit = 0;
 
 /* Maximum buffer usage. */
 extern PIO_Offset maxusage;
@@ -52,6 +52,11 @@ void *bpool_alloc(bufsize sz)
  */
 int compute_buffer_init(iosystem_desc_t *ios)
 {
+    /* Default block size increment = 32 MB */
+    const bufsize DEFAULT_BUF_INC_SZ = (bufsize ) (32L * 1024L * 1024L);
+    bufsize bpool_block_inc_sz = (bufsize )((pio_buffer_size_limit > 0) ? pio_buffer_size_limit : DEFAULT_BUF_INC_SZ);
+    LOG((2, "Initializing buffer pool with block increment = %lld bytes", (long long int) bpool_block_inc_sz));
+    pio_cnbuffer_limit = bpool_block_inc_sz;
 #if PIO_USE_MALLOC
     bpool(NULL, pio_cnbuffer_limit);
 #else

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -288,8 +288,6 @@ extern "C" {
     /* Initialize the compute buffer. */
     int compute_buffer_init(iosystem_desc_t *ios);
 
-    void free_cn_buffer_pool(iosystem_desc_t *ios);
-
     /* Flush PIO's data buffer. */
     int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk);
 

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1166,13 +1166,6 @@ int PIOc_finalize(int iosysid)
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     LOG((2, "%d iosystems are still open.", niosysid));
 
-    /* Only free the buffer pool if this is the last open iosysid. */
-    if (niosysid == 1)
-    {
-        free_cn_buffer_pool(ios);
-        LOG((2, "Freed buffer pool."));
-    }
-
     /* Free the MPI groups. */
     if (ios->compgroup != MPI_GROUP_NULL)
         MPI_Group_free(&ios->compgroup);


### PR DESCRIPTION
This PR includes several changes to the way PIO uses the BGET memory management package.

* Removes global compute node buffer block and related code
* Simplifies and fixes issues with BGET usage
* Allows users to control the amount of memory allocated by BGET

Fixes #211 
Fixes #209  