### PR TITLE
Update the condition used to retry opening a file

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2434,7 +2434,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
             if(mpierr != MPI_SUCCESS){
                 return check_mpi(NULL, file, ierr, __FILE__, __LINE__);
             }
-            if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
+            if ((ierr != NC_NOERR) && (file->iotype != PIO_IOTYPE_NETCDF))
             {
                 if (ios->iomaster == MPI_ROOT)
                     printf("PIO2 pio_file.c retry NETCDF\n");


### PR DESCRIPTION
If PIO fails to open a file due to an incompatible type of NetCDF,
it incorrectly assumes that the returned error code from
nc_open/nc_open_par/ncmpi_open is either NC_ENOTNC
or NC_EINVAL. When an unexpected error code like
NC_ENOTNC3 is returned, PIO will not give it a retry despite
the caller's request.

For a hard retry, any error code except PIO_NOERR is expected
from nc_open/nc_open_par/ncmpi_open.

Fixes #210