### PR TITLE
Fix c99 flag for PGI

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -33,6 +33,8 @@ target_compile_definitions (pioc
 string (TOUPPER "${CMAKE_C_COMPILER_ID}" CMAKE_C_COMPILER_NAME)
 if (CMAKE_C_COMPILER_NAME STREQUAL "CRAY")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -h std=c99")
+elseif (CMAKE_C_COMPILER_NAME STREQUAL "PGI")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -c99")
 else ()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 endif ()

--- a/tests/cunit/CMakeLists.txt
+++ b/tests/cunit/CMakeLists.txt
@@ -6,6 +6,8 @@ include_directories("${CMAKE_SOURCE_DIR}/tests/cunit" "${CMAKE_BINARY_DIR}/src/c
 string (TOUPPER "${CMAKE_C_COMPILER_ID}" CMAKE_C_COMPILER_NAME)
 if (CMAKE_C_COMPILER_NAME STREQUAL "CRAY")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -h std=c99")
+elseif (CMAKE_C_COMPILER_NAME STREQUAL "PGI")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -c99")
 else ()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 endif ()


### PR DESCRIPTION
The PGI C compiler does not support "-std=c99" format for
specifying standard conformance (uses "-c99" instead)

Fixes #218