### PR TITLE
Update GPTL timers

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -1041,6 +1041,9 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
         ierr = PIOc_write_darray_adios(file, varid, ioid, iodesc, arraylen, array, fillvalue);
+#ifdef TIMING
+        GPTLstop("PIO:PIOc_write_darray");
+#endif
         return ierr;
     }
 #endif

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -236,6 +236,11 @@ int PIOc_closefile(int ncid)
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
+#ifdef TIMING
+    if (file->mode & PIO_WRITE)
+        GPTLstart("PIO:PIOc_closefile_write_mode");
+#endif
+
     /* Sync changes before closing on all tasks if async is not in
      * use, but only on non-IO tasks if async is in use. */
     if (!ios->async || !ios->ioproc)
@@ -366,6 +371,11 @@ int PIOc_closefile(int ncid)
         LOG((1, "nc*_close failed, ierr = %d", ierr));
         return ierr;
     }
+
+#ifdef TIMING
+    if (file->mode & PIO_WRITE)
+        GPTLstop("PIO:PIOc_closefile_write_mode");
+#endif
 
     /* Delete file from our list of open files. */
     pio_delete_file_from_list(ncid);


### PR DESCRIPTION
Stop timer PIO:PIOc_write_darray for ADIOS type.
This is missing in existing code.

Also, a new timer is created for closing files in write mode.
To get a more accurate write bandwidth of an E3SM case run,
we need a specific GPTL timer on closing files that are created
or opened with PIO_WRITE mode.

Fixes #130