### PR TITLE
Resolve overlapped run time for PIOc_sync and PIOc_closefile 

### DIFF
--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -208,6 +208,114 @@ int PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
     return PIOc_createfile_int(iosysid, ncidp, &iotype, filename, cmode);
 }
 
+/* Internal helper function to perform sync operations
+ * ncid : the ncid of the file to sync
+ * Returns PIO_NOERR for success, error code otherwise
+ */
+static int sync_file(int ncid)
+{
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
+    file_desc_t *file;     /* Pointer to file information. */
+    int ierr = PIO_NOERR;  /* Return code from function calls. */
+
+    LOG((1, "sync_file ncid = %d", ncid));
+
+    /* Get the file info from the ncid. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
+
+#ifdef _ADIOS
+    if (file->iotype == PIO_IOTYPE_ADIOS)
+        return PIO_NOERR;
+#endif
+
+    ios = file->iosystem;
+
+    /* Flush data buffers on computational tasks. */
+    if (!ios->async || !ios->ioproc)
+    {
+        if (file->mode & PIO_WRITE)
+        {
+            wmulti_buffer *wmb, *twmb;
+
+            LOG((3, "sync_file checking buffers"));
+            wmb = &file->buffer;
+            while (wmb)
+            {
+                /* If there are any data arrays waiting in the
+                 * multibuffer, flush it to IO tasks. */
+                if (wmb->num_arrays > 0)
+                    flush_buffer(ncid, wmb, false);
+                twmb = wmb;
+                wmb = wmb->next;
+                if (twmb == &file->buffer)
+                {
+                    twmb->ioid = -1;
+                    twmb->next = NULL;
+                }
+                else
+                {
+                    free(twmb);
+                }
+            }
+        }
+    }
+
+    /* If async is in use, send message to IO master tasks. */
+    if (ios->async)
+    {
+        int msg = PIO_MSG_SYNC;
+
+        PIO_SEND_ASYNC_MSG(ios, msg, &ierr, ncid);
+        if (ierr != PIO_NOERR)
+        {
+            LOG((1, "Error sending async msg for PIO_MSG_SYNC"));
+            return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        }
+    }
+
+    /* Call the sync function on IO tasks. */
+    if (file->mode & PIO_WRITE)
+    {
+        if (ios->ioproc)
+        {
+            switch (file->iotype)
+            {
+#ifdef _NETCDF4
+            case PIO_IOTYPE_NETCDF4P:
+                ierr = nc_sync(file->fh);
+                break;
+            case PIO_IOTYPE_NETCDF4C:
+#endif
+#ifdef _NETCDF
+            case PIO_IOTYPE_NETCDF:
+                if (ios->io_rank == 0)
+                    ierr = nc_sync(file->fh);
+                break;
+#endif
+#ifdef _PNETCDF
+            case PIO_IOTYPE_PNETCDF:
+                flush_output_buffer(file, true, 0);
+                ierr = ncmpi_sync(file->fh);
+                break;
+#endif
+            default:
+                return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
+            }
+        }
+        LOG((2, "sync_file ierr = %d", ierr));
+    }
+
+    ierr = check_netcdf(ios, NULL, ierr, __FILE__, __LINE__);
+    if (ierr != PIO_NOERR)
+    {
+        LOG((1, "nc*_sync failed, ierr = %d", ierr));
+        return ierr;
+    }
+
+    return PIO_NOERR;
+}
+
 /**
  * Close a file previously opened with PIO.
  *
@@ -245,7 +353,7 @@ int PIOc_closefile(int ncid)
      * use, but only on non-IO tasks if async is in use. */
     if (!ios->async || !ios->ioproc)
         if (file->mode & PIO_WRITE)
-            PIOc_sync(ncid);
+            sync_file(ncid);
 
     /* If async is in use and this is a comp tasks, then the compmaster
      * sends a msg to the pio_msg_handler running on the IO master and
@@ -470,9 +578,6 @@ int PIOc_deletefile(int iosysid, const char *filename)
  */
 int PIOc_sync(int ncid)
 {
-    iosystem_desc_t *ios;  /* Pointer to io system information. */
-    file_desc_t *file;     /* Pointer to file information. */
-    int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;  /* Return code from function calls. */
 
 #ifdef TIMING
@@ -481,103 +586,7 @@ int PIOc_sync(int ncid)
 
     LOG((1, "PIOc_sync ncid = %d", ncid));
 
-    /* Get the file info from the ncid. */
-    if ((ierr = pio_get_file(ncid, &file)))
-        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
-    ios = file->iosystem;
-
-#ifdef _ADIOS
-    if (file->iotype != PIO_IOTYPE_ADIOS)
-    {
-#endif
-
-    /* Flush data buffers on computational tasks. */
-    if (!ios->async || !ios->ioproc)
-    {
-        if (file->mode & PIO_WRITE)
-        {
-            wmulti_buffer *wmb, *twmb;
-
-            LOG((3, "PIOc_sync checking buffers"));
-            wmb = &file->buffer;
-            while (wmb)
-            {
-                /* If there are any data arrays waiting in the
-                 * multibuffer, flush it to IO tasks. */
-                if (wmb->num_arrays > 0)
-                    flush_buffer(ncid, wmb, false);
-                twmb = wmb;
-                wmb = wmb->next;
-                if (twmb == &file->buffer)
-                {
-                    twmb->ioid = -1;
-                    twmb->next = NULL;
-                }
-                else
-                {
-                    free(twmb);
-                }
-            }
-        }
-    }
-
-    /* If async is in use, send message to IO master tasks. */
-    if (ios->async)
-    {
-        int msg = PIO_MSG_SYNC;
-
-        PIO_SEND_ASYNC_MSG(ios, msg, &ierr, ncid);
-        if(ierr != PIO_NOERR)
-        {
-            LOG((1, "Error sending async msg for PIO_MSG_SYNC"));
-            return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
-        }
-    }
-
-    /* Call the sync function on IO tasks. */
-    if (file->mode & PIO_WRITE)
-    {
-        if (ios->ioproc)
-        {
-            switch(file->iotype)
-            {
-#ifdef _NETCDF4
-            case PIO_IOTYPE_NETCDF4P:
-                ierr = nc_sync(file->fh);
-                break;
-            case PIO_IOTYPE_NETCDF4C:
-#endif
-#ifdef _NETCDF
-            case PIO_IOTYPE_NETCDF:
-                if (ios->io_rank == 0)
-                    ierr = nc_sync(file->fh);
-                break;
-#endif
-#ifdef _PNETCDF
-            case PIO_IOTYPE_PNETCDF:
-                flush_output_buffer(file, true, 0);
-                ierr = ncmpi_sync(file->fh);
-                break;
-#endif
-            default:
-                return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
-            }
-        }
-        LOG((2, "PIOc_sync ierr = %d", ierr));
-    }
-
-#ifdef _ADIOS
-    }
-#endif
-
-    ierr = check_netcdf(ios, NULL, ierr, __FILE__, __LINE__);
-    if(ierr != PIO_NOERR){
-#ifdef TIMING
-        GPTLstop("PIO:PIOc_sync");
-#endif
-        LOG((1, "nc*_sync failed, ierr=%d", ierr));
-        return ierr;
-    }
+    ierr = sync_file(ncid);
 
 #ifdef TIMING
     GPTLstop("PIO:PIOc_sync");


### PR DESCRIPTION
In existing PIO2 code, PIOc_closefile() calls PIOc_sync() to flush
data to disk. As a result, a timer used to capture the cost of
PIOc_closefile() would include the cost of the PIOc_sync() call
inside the function.

A new internal helper function, sync_file(), is introduced to perform
sync operations. It is used by both PIOc_sync() and PIOc_closefile(),
such that they no longer have overlapped run time.

Also, we choose not to call ncmpi_sync() for PIO_IOTYPE_PNETCDF
inside sync_file(), as that PnetCDF API has been confirmed to have a
very high cost on some systems.

Fixes #225
Fixes #223