### PR TITLE
Modify the user-specified iotype when internally switching iotypes

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2445,6 +2445,9 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
                 /* reset file markers for NETCDF on all tasks */
                 file->iotype = PIO_IOTYPE_NETCDF;
 
+                /* modify the user-specified iotype on all tasks */
+                *iotype = PIO_IOTYPE_NETCDF;
+
                 /* open netcdf file serially on main task */
                 if (ios->io_rank == 0)
                 {


### PR DESCRIPTION
When internally switching iotypes (if the user-specified iotype
fails to open a file) PIO should modify the user-specified iotype
to reflect the implicit type change.

A similar update has already been applied to internally maintained
iotype associated with the file (file->iotype).

Fixes #85