### PR TITLE
Fix broken async C unit tests run with GCC 8.2 and LeakSanitizer

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -110,7 +110,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     io_desc_t *iodesc;     /* Pointer to IO description information. */
     int rlen;              /* Total data buffer size. */
     var_desc_t *vdesc0;    /* Array of var_desc structure for each var. */
-    int fndims;            /* Number of dims in the var in the file. */
+    int fndims = 0;        /* Number of dims in the var in the file. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function calls. */
     int ierr = PIO_NOERR;              /* Return code. */
 

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -34,8 +34,8 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
-    PIO_Offset atttype_len;    /* Length (in bytes) of the att type in file. */
-    PIO_Offset memtype_len;    /* Length of the att data type in memory. */
+    PIO_Offset atttype_len = 0;    /* Length (in bytes) of the att type in file. */
+    PIO_Offset memtype_len = 0;    /* Length of the att data type in memory. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;           /* Return code from function calls. */
 
@@ -269,10 +269,10 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
 {
     iosystem_desc_t *ios;   /* Pointer to io system information. */
     file_desc_t *file;      /* Pointer to file information. */
-    nc_type atttype;        /* The type of the attribute. */
-    PIO_Offset attlen;      /* Number of elements in the attribute array. */
-    PIO_Offset atttype_len; /* Length in bytes of one element of the attribute type. */
-    PIO_Offset memtype_len; /* Length in bytes of one element of the memory type. */
+    nc_type atttype = NC_NAT;   /* The type of the attribute. */
+    PIO_Offset attlen = 0;      /* Number of elements in the attribute array. */
+    PIO_Offset atttype_len = 0; /* Length in bytes of one element of the attribute type. */
+    PIO_Offset memtype_len = 0; /* Length in bytes of one element of the memory type. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function calls. */
     int ierr = PIO_NOERR;               /* Return code from function calls. */
 
@@ -500,10 +500,10 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
-    int ndims;             /* The number of dimensions in the variable. */
-    PIO_Offset typelen;    /* Size (in bytes) of the data type of data in buf. */
+    int ndims = 0;         /* The number of dimensions in the variable. */
+    PIO_Offset typelen = 0; /* Size (in bytes) of the data type of data in buf. */
     PIO_Offset num_elem = 1; /* Number of data elements in the buffer. */
-    nc_type vartype;         /* The type of the var we are reading from. */
+    nc_type vartype = NC_NAT; /* The type of the var we are reading from. */
     char start_present = start ? true : false;
     char count_present = count ? true : false;
     char stride_present = stride ? true : false;
@@ -915,15 +915,15 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;  /* Pointer to file information. */
-    int ndims;          /* The number of dimensions in the variable. */
-    PIO_Offset typelen; /* Size (in bytes) of the data type of data in buf. */
+    int ndims = 0;      /* The number of dimensions in the variable. */
+    PIO_Offset typelen = 0; /* Size (in bytes) of the data type of data in buf. */
     PIO_Offset num_elem = 1; /* Number of data elements in the buffer. */
     char start_present = start ? true : false;    /* Is start non-NULL? */
     char count_present = count ? true : false;    /* Is count non-NULL? */
     char stride_present = stride ? true : false;  /* Is stride non-NULL? */
     var_desc_t *vdesc;
     int *request;
-    nc_type vartype;   /* The type of the var we are reading from. */
+    nc_type vartype = NC_NAT;   /* The type of the var we are reading from. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;          /* Return code from function calls. */
 

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2482,8 +2482,8 @@ int PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_value
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
-    nc_type xtype;         /* The type of the variable (and fill value att). */
-    PIO_Offset type_size;  /* Size in bytes of this variable's type. */
+    nc_type xtype = NC_NAT;    /* The type of the variable (and fill value att). */
+    PIO_Offset type_size = 0;  /* Size in bytes of this variable's type. */
     int ierr = PIO_NOERR;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
@@ -2618,8 +2618,8 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
-    nc_type xtype;         /* Type of variable and its _FillValue attribute. */
-    PIO_Offset type_size;  /* Size in bytes of this variable's type. */
+    nc_type xtype = NC_NAT;  /* Type of variable and its _FillValue attribute. */
+    PIO_Offset type_size = 0;  /* Size in bytes of this variable's type. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;  /* Return code from function calls. */
 

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -320,7 +320,7 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
     file_desc_t *file;     /* Pointer to file information. */
     int ierr = PIO_NOERR;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
-    int ndims; /* The number of dimensions in the variable. */
+    int ndims = 0; /* The number of dimensions in the variable. */
 
     LOG((1, "PIOc_inq_var_chunking ncid = %d varid = %d"));
 


### PR DESCRIPTION
Some variables are only updated on non-IO tasks if async is in use.
Initialize these variables to make sure that they do not have garbage
values on IO tasks.

Fixes #230