### PR TITLE
Explicitly set CMake variable CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -21,3 +21,5 @@ else ()
     set (CTEST_DROP_LOCATION "/submit.php?project=PIO")
 endif ()
 set (CTEST_DROP_SITE_CDASH TRUE)
+
+set (CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000)


### PR DESCRIPTION
According to CMake documentation, this variable specifies the
maximum number of warnings in a single build step which will
be detected. After this, the ctest_test() command will truncate
the output. Defaults to 50.

Increase the default value to allow CDash to display more than
50 warnings (up to 1000).

See issue #233