### PR TITLE
Changing proj name and version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required (VERSION 2.8.12)
-project (PIO C CXX Fortran)
+cmake_minimum_required (VERSION 1.0.0)
+project (SCORPIO C CXX Fortran)
 #cmake_policy(VERSION 3.5.2)
 
 # The project version number.
-set(VERSION_MAJOR   2   CACHE STRING "Project major version number.")
+set(VERSION_MAJOR   1   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   0   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH  28   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 #==============================================================================
@@ -17,10 +17,10 @@ option (PIO_ENABLE_FORTRAN   "Enable the Fortran library builds"            ON)
 option (PIO_ENABLE_TIMING    "Enable the use of the GPTL timing library"    ON)
 option (PIO_ENABLE_INTERNAL_TIMING    "Gather and print GPTL timing stats"  OFF)
 option (PIO_ENABLE_LOGGING   "Enable debug logging (large output possible)" OFF)
-option (PIO_ENABLE_DOC       "Enable building PIO documentation"            ON)
+option (PIO_ENABLE_DOC       "Enable building SCORPIO documentation"            ON)
 option (PIO_ENABLE_COVERAGE  "Enable code coverage"                         OFF)
-option (PIO_ENABLE_EXAMPLES  "Enable PIO examples"                          ON)
-option (PIO_INTERNAL_DOC     "Enable PIO developer documentation"           OFF)
+option (PIO_ENABLE_EXAMPLES  "Enable SCORPIO examples"                          ON)
+option (PIO_INTERNAL_DOC     "Enable SCORPIO developer documentation"           OFF)
 option (PIO_TEST_BIG_ENDIAN  "Enable test to see if machine is big endian"  ON)
 option (PIO_USE_MPIIO        "Enable support for MPI-IO auto detect"        ON)
 option (PIO_USE_MPISERIAL    "Enable mpi-serial support (instead of MPI)"   OFF)
@@ -112,7 +112,7 @@ option (PIO_ENABLE_TESTS  "Enable the testing builds"                           
 option (PIO_ENABLE_LARGE_TESTS  "Enable large (file, processes) tests"         OFF)
 option (PIO_VALGRIND_CHECK  "Enable memory leak check using valgrind"           OFF)
 include(CMakeDependentOption)
-cmake_dependent_option (PIO_TEST_CLOSE_OPEN_FOR_SYNC  "PIO fortran tests will close+open for sync" ON "WITH_ADIOS" OFF)
+cmake_dependent_option (PIO_TEST_CLOSE_OPEN_FOR_SYNC  "SCORPIO fortran tests will close+open for sync" ON "WITH_ADIOS" OFF)
 
 #==============================================================================
 #  BACKWARDS COMPATIBILITY
@@ -168,7 +168,7 @@ configure_file (
 # Regex is only available in GCC 4.9+ (> 4.8)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.8)
-    message (FATAL_ERROR "PIO requires GCC 4.9+ to build correctly")
+    message (FATAL_ERROR "SCORPIO requires GCC 4.9+ to build correctly")
   endif()
 endif ()
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ParallelIO
+# Software for Caching Output and Reads for Parallel I/O (SCORPIO)
 
 A high-level Parallel I/O Library for structured grid applications
 
@@ -13,7 +13,7 @@ cdash site at [http://my.cdash.org/index.php?project=PIO](http://my.cdash.org/in
 
 ## Dependencies
 
-PIO can use NetCDF (version 4.3.3+) and/or PnetCDF (version 1.6.0+) for I/O.
+SCORPIO can use NetCDF (version 4.3.3+) and/or PnetCDF (version 1.6.0+) for I/O.
 Ideally, the NetCDF version should be built with MPI, which requires that it
 be linked with an MPI-enabled version of HDF5.  Optionally, NetCDF can be 
 built with DAP support, which introduces a dependency on CURL.  Additionally,
@@ -21,7 +21,7 @@ HDF5, itself, introduces dependencies on LIBZ and (optionally) SZIP.
 
 ## Configuring with CMake
 
-To configure the build, PIO requires CMake version 2.8.12+.  The typical
+To configure the build, SCORPIO requires CMake version 2.8.12+.  The typical
 configuration with CMake can be done as follows:
 
 ```
@@ -56,35 +56,35 @@ This works for the dependencies: `NetCDF`, `PnetCDF`, `HDF5`, `LIBZ`, `SZIP`.
 Additional configuration options can be specified on the command line.
 
 The `PIO_ENABLE_TIMING` option can be set to `ON` or `OFF` to enable or
-disable the use of GPTL timing in the PIO libraries.  This feature requires
-the GPTL C library for the PIO `C` library and the GPTL Fortran library with
+disable the use of GPTL timing in the SCORPIO libraries.  This feature requires
+the GPTL C library for the SCORPIO `C` library and the GPTL Fortran library with
 the `perf_mod.mod` and `perf_utils.mod` interface modules.  If these GPTL
-libraries are already installed on the system, the user can point PIO to the
+libraries are already installed on the system, the user can point SCORPIO to the
 location of these libraries with the `GPTL_PATH` variable (or, individually,
 `GPTL_C_PATH` and `GPTL_Fortran_Perf_PATH` variables).  However, if these
 GPTL libraries are not installed on the system, and GPTL cannot be found,
-then PIO will build its own internal version of GPTL.  
+then SCORPIO will build its own internal version of GPTL.
 
 If PnetCDF is not installed on the system, the user can disable its use by
 setting `-DWITH_PNETCDF=OFF`.  This will disable the search for PnetCDF on the
-system and disable the use of PnetCDF from within PIO.
+system and disable the use of PnetCDF from within SCORPIO.
 
 NetCDF is optional if PnetCDF is used, and the user can disable its use by
 setting `-DWITH_NETCDF=OFF`.  This will disable the search for NetCDF on the
-system and disable the use of NetCDF from within PIO.
+system and disable the use of NetCDF from within SCORPIO.
 
-If the user wishes to disable the PIO tests, then the user can set the
+If the user wishes to disable the SCORPIO tests, then the user can set the
 variable `-DPIO_ENABLE_TESTS=OFF`.  This will entirely disable the CTest 
 testing suite, as well as remove all of the test build targets.
 
-If you wish to install PIO in a safe location for use later with other
+If you wish to install SCORPIO in a safe location for use later with other
 software, you may set the `CMAKE_INSTALL_PREFIX` variable to point to the
 desired install location.
 
 ## Building
 
-Once you have successfully configured PIO with CMake in a build directory.
-From within the build directory, build PIO with:
+Once you have successfully configured SCORPIO with CMake in a build directory.
+From within the build directory, build SCORPIO with:
 
 ```
 make
@@ -131,7 +131,7 @@ Hence, you should not further preface the `ctest` command with these MPI launche
 
 ## Installing
 
-Once you have built the PIO libraries, you may install them in the location
+Once you have built the SCORPIO libraries, you may install them in the location
 specified by the `CMAKE_INSTALL_PREFIX`.  To do this, simply type:
 
 ```
@@ -140,4 +140,4 @@ make install
 
 If the internal GPTL libraries were built (because GPTL could not be found
 and the `PIO_ENABLE_TIMING` variable is set to `ON`), then these libraries
-will be installed with PIO.
+will be installed with SCORPIO.


### PR DESCRIPTION
Changing project name from PIO to SCORPIO in main source tree.

Re-setting version to 1.0.0 for the initial release.