### PR TITLE
Reverting cmake min ver reqd to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 1.0.0)
+cmake_minimum_required (VERSION 2.8.12)
 project (SCORPIO C CXX Fortran)
 #cmake_policy(VERSION 3.5.2)
 


### PR DESCRIPTION
The CMake min version reqd was inadvertently changed in
e3b3c5255910af8907f919e62f4320aba90d2c33 to 1.0.0

Reverting it back to 2.8.12