### PR TITLE
Disable modifying user iotype

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2816,7 +2816,16 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
                 file->iotype = PIO_IOTYPE_NETCDF;
 
                 /* modify the user-specified iotype on all tasks */
-                *iotype = PIO_IOTYPE_NETCDF;
+                /* Modifying the user-specified iotype unfortunately
+                 * causes some E3SM model components to reset the iotype
+                 * to NetCDF for all subsequent reads and writes
+                 * (eventhough only some files read are in the NetCDF4
+                 * format)
+                 * Commenting this out for now, until we introduce
+                 * PIO_IOTYPE_ANY that would allow users to explicitly
+                 * specify that the lib can internally modify iotypes
+                 */
+                /* *iotype = PIO_IOTYPE_NETCDF; */
 
                 /* open netcdf file serially on main task */
                 if (ios->io_rank == 0)


### PR DESCRIPTION
When SCORPIO is unable to open a file with PnetCDF it internally
retries by switching the iotype to NetCDF. The library also modifies
the user specified iotype as required.

Unfortunately this causes some E3SM model components to reset the
iotype, if a read of a NetCDF4 file fails with PnetCDF, to NetCDF.
So all subsequent reads and writes use the NetCDF iotype adversely
affecting the performance. So disabling modifying the user type
for now.

So reverting changes made in PR #227