### PR TITLE
Avoid assigning character fillval to an integer (scorpio classic)

### DIFF
--- a/pio/pio_types.F90
+++ b/pio/pio_types.F90
@@ -368,7 +368,7 @@ module pio_types
    integer, public, parameter :: PIO_MAX_VAR_DIMS = nf90_max_var_dims
    integer, public, parameter :: PIO_64BIT_OFFSET = nf90_64bit_offset
    integer, public, parameter :: PIO_64BIT_DATA = 0
-   integer, public, parameter :: PIO_FILL_CHAR = nf90_fill_char
+   integer, public, parameter :: PIO_FILL_CHAR = iachar(nf90_fill_char)
    integer, public, parameter :: PIO_FILL_INT = nf90_fill_int
    real, public, parameter :: PIO_FILL_FLOAT = nf90_fill_float
    double precision, public, parameter :: PIO_FILL_DOUBLE = nf90_fill_double
@@ -387,7 +387,7 @@ module pio_types
    integer, public, parameter :: PIO_NOWRITE = 21
    integer, public, parameter :: PIO_64BIT_OFFSET = 0
    integer, public, parameter :: PIO_64BIT_DATA = 0
-   integer, public, parameter :: PIO_FILL_CHAR = achar(0)
+   integer, public, parameter :: PIO_FILL_CHAR = 0
    integer, public, parameter :: PIO_FILL_INT = -2147483647
    real, public, parameter :: PIO_FILL_FLOAT = 9.9692099683868690e+36
    double precision, public, parameter :: PIO_FILL_DOUBLE = 9.9692099683868690e+36


### PR DESCRIPTION
This PR converts NetCDF Fortran character fillvalue to integer
before using it to initialize the PIO fillvalue (an integer)

Fixes #251