### PR TITLE
Fix issues with HDF5 variables using dimensions associated with coordinate variables

### DIFF
--- a/src/clib/pioc_support.cpp
+++ b/src/clib/pioc_support.cpp
@@ -7159,6 +7159,7 @@ int spio_hdf5_enddef(iosystem_desc_t *ios, file_desc_t *file)
     assert((file->iotype == PIO_IOTYPE_HDF5) || (file->iotype == PIO_IOTYPE_HDF5C));
     assert(ios->ioproc);
 
+  /* Step 1 : Process dimensions with no coordinate variables associated with it */
     for (i = 0; i < file->hdf5_num_dims; i++)
     {
         /* For dimensions without an associated coordinate var, define them here. However since the
@@ -7327,6 +7328,7 @@ int spio_hdf5_enddef(iosystem_desc_t *ios, file_desc_t *file)
         }
     }
 
+    /* Step 2 : Process coordinate variables and associated dimensions */
     for(i = 0; i < file->hdf5_num_vars; i++){
       /* Upgrade the dataset of a coordinate variable to a dimension scale */
       if(file->hdf5_vars[i].is_coord_var){
@@ -7403,7 +7405,14 @@ int spio_hdf5_enddef(iosystem_desc_t *ios, file_desc_t *file)
                          pio_get_fname_from_file(file), file->pio_ncid);
         }
       }
-      else{
+    }
+
+    /* Step 3 : Process rest of the variables (These are non-coordinate variables). The coordinate
+     * variables and associated dimensions need to be defined (Step 2) before we start processing
+     * all variables.
+     */
+    for(i = 0; i < file->hdf5_num_vars; i++){
+      if(!file->hdf5_vars[i].is_coord_var){
         /* Not a coordinate var */
         int ndims = file->hdf5_vars[i].ndims;
         if(ndims > 0){
@@ -7426,7 +7435,6 @@ int spio_hdf5_enddef(iosystem_desc_t *ios, file_desc_t *file)
         }
       }
     }
-
     return PIO_NOERR;
 }
 

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -297,6 +297,154 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_1dvar
 
+! Put and get a single coordinate variable (dimension and variable with the same name e.g. lon[lon])
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1d_coord_var
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(var_desc_t)  :: pio_var
+  integer :: pio_dim
+  integer, parameter :: DIM_LEN = 100
+  PIO_TF_FC_DATA_TYPE, dimension(DIM_LEN) :: pval, gval
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  character(len=*), parameter :: PIO_VAR_NAME = 'dummy_coord_var'
+  integer :: num_iotypes
+  integer :: i, ret
+
+  pval = pio_tf_world_sz_
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_ncdf_get_put.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ! Since file is just created no need to enter redef
+    ret = PIO_def_dim(pio_file, PIO_VAR_NAME, DIM_LEN, pio_dim)
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to define coord var:" // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ret = PIO_put_var(pio_file, pio_var, pval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put coord var:" // trim(filename))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to get coord var:" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    gval = 0
+    ret = PIO_get_var(pio_file, pio_var, gval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get coord var:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gval, pval), "Got wrong value")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_1d_coord_var
+
+! Put and get multiple variables and coordinate variables
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1d_coord_mvars
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(var_desc_t)  :: pio_var, pio_var2
+  integer :: pio_dim
+  integer, parameter :: DIM_LEN = 100
+  PIO_TF_FC_DATA_TYPE, dimension(DIM_LEN) :: pval, gval
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  character(len=*), parameter :: PIO_CVAR_NAME = 'dummy_coord_var'
+  character(len=*), parameter :: PIO_VAR_NAME = 'dummy_var'
+  integer :: num_iotypes
+  integer :: i, ret
+
+  pval = pio_tf_world_sz_
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_ncdf_get_put.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ! Since file is just created no need to enter redef
+    ret = PIO_def_dim(pio_file, PIO_CVAR_NAME, DIM_LEN, pio_dim)
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
+    PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_CVAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to define coord var:" // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ret = PIO_put_var(pio_file, pio_var, pval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put coord var:" // trim(filename))
+
+    ret = PIO_put_var(pio_file, pio_var2, pval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put var:" // trim(filename))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_CVAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to get coord var:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ret, "Failed to get var:" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    gval = 0
+    ret = PIO_get_var(pio_file, pio_var, gval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get coord var:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gval, pval), "Got wrong value")
+
+    gval = 0
+    ret = PIO_get_var(pio_file, pio_var2, gval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get var:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gval, pval), "Got wrong value")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_1d_coord_mvars
+
 ! Put and get variables with large/small (compared to the variable size) user buffers
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_ls_buf


### PR DESCRIPTION
Fixing order of creation of variables so that dimensions are
defined before they are being used, specifically for dims
associated with coordinate variables.

Also adding test cases that show the issue with variables
using undefined dimensions.

Fixes #682 