### PR TITLE
Disable PIO_IOTYPE_HDF5C when compression is not enabled

### DIFF
--- a/src/clib/core/pioc_support.cpp
+++ b/src/clib/core/pioc_support.cpp
@@ -5750,8 +5750,11 @@ int iotype_is_valid(int iotype)
 
     /* Some builds include hdf5. */
 #ifdef _HDF5
-    if ((iotype == PIO_IOTYPE_HDF5) || (iotype == PIO_IOTYPE_HDF5C))
-        ret++;
+    if(iotype == PIO_IOTYPE_HDF5) { ret++; }
+#ifdef _SPIO_HDF5_USE_COMPRESSION
+    if(iotype == PIO_IOTYPE_HDF5C) { ret++; }
+#endif
+
 #endif /* _HDF5 */
 
     return ret;


### PR DESCRIPTION
Return an error when the user uses PIO_IOTYPE_HDF5C
and data compression is not enabled.