### PR TITLE
Adding support for MPI serial library

### DIFF
--- a/src/clib/core/pioc.cpp
+++ b/src/clib/core/pioc.cpp
@@ -1547,8 +1547,13 @@ int PIOc_Init_Intracomm_impl(MPI_Comm comp_comm, int num_iotasks, int stride, in
 
     /* Create the node local comm - all procs in comp_comm that are local to
      * this compute node (share memory) */
+#ifndef MPI_SERIAL
     mpierr = MPI_Comm_split_type(ios->comp_comm, MPI_COMM_TYPE_SHARED, 0,
               ios->info, &(ios->node_comm));
+#else
+    /* MPI serial library does not support MPI_Comm_split_type() */
+    mpierr = MPI_Comm_dup(ios->comp_comm, &(ios->node_comm));
+#endif
     if(mpierr != MPI_SUCCESS){
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     }
@@ -2472,8 +2477,13 @@ int PIOc_init_async_impl(MPI_Comm world, int num_io_procs, const int *io_proc_li
 
                 /* Create the node local comm - all procs in comp_comm that are local to
                  * this compute node (share memory) */
+#ifndef MPI_SERIAL
                 mpierr = MPI_Comm_split_type(my_iosys->comp_comm, MPI_COMM_TYPE_SHARED, 0,
                           my_iosys->info, &(my_iosys->node_comm));
+#else
+                /* MPI serial lib does not support MPI_Comm_split_type() */
+                mpierr = MPI_Comm_dup(my_iosys->comp_comm, &(my_iosys->node_comm));
+#endif
                 if(mpierr != MPI_SUCCESS){
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
                 }
@@ -3072,8 +3082,13 @@ int PIOc_init_intercomm_impl(int component_count, const MPI_Comm peer_comm,
 
                 /* Create the node local comm - all procs in comp_comm that are local to
                  * this compute node (share memory) */
+#ifndef MPI_SERIAL
                 ret = MPI_Comm_split_type(iosys[i]->comp_comm, MPI_COMM_TYPE_SHARED, 0,
                           iosys[i]->info, &(iosys[i]->node_comm));
+#else
+                /* MPI Serial lib does not support MPI_Comm_split_type() */
+                ret = MPI_Comm_dup(iosys[i]->comp_comm, &(iosys[i]->node_comm));
+#endif
                 if(ret != MPI_SUCCESS){
                     return check_mpi(NULL, NULL, ret, __FILE__, __LINE__);
                 }

--- a/src/clib/core/progress_engine/spio_async_tcomm.hpp
+++ b/src/clib/core/progress_engine/spio_async_tcomm.hpp
@@ -5,8 +5,17 @@
 #include <thread>
 #include <chrono>
 #include <list>
-#include "mpi.h"
+#include <vector>
 #include "pio_config.h"
+#ifdef MPI_SERIAL
+extern "C" {
+#endif
+
+#include "mpi.h"
+
+#ifdef MPI_SERIAL
+}
+#endif
 #include "spio_async_tpool.hpp"
 
 namespace SPIO_Util{

--- a/src/clib/core/util/spio_decomp_logger.hpp
+++ b/src/clib/core/util/spio_decomp_logger.hpp
@@ -190,7 +190,12 @@ namespace SPIO_Util{
       int ret = MPI_SUCCESS;
       
       ret = MPI_Comm_dup(ucomm, &comm); assert(ret == MPI_SUCCESS);
+#ifndef MPI_SERIAL
       ret = MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &agg_comm); assert(ret == MPI_SUCCESS);
+#else
+      /* MPI serial library does not have support for MPI_Comm_split_type() */
+      ret = MPI_Comm_dup(comm, &agg_comm); assert(ret == MPI_SUCCESS);
+#endif
       ret = MPI_Comm_rank(agg_comm, &agg_comm_rank); assert(ret == MPI_SUCCESS);
 
       int color = (agg_comm_rank == 0) ? 0 : MPI_UNDEFINED;

--- a/tests/cunit/test_req_block_wait.cpp
+++ b/tests/cunit/test_req_block_wait.cpp
@@ -1,4 +1,3 @@
-#include "mpi.h"
 #include "pio.h"
 #include "pio_internal.h"
 #include "pio_minmax.h"

--- a/tests/cunit/test_spio_rearr_utils_gather.cpp
+++ b/tests/cunit/test_spio_rearr_utils_gather.cpp
@@ -221,12 +221,17 @@ int test_gatherw_contig_block_decomp(MPI_Comm comm, int wrank, int wsz)
       recvcounts[i] = 1;
       rdispls[i] = i * LOCAL_SZ * sizeof(double);
 
+#ifndef MPI_SERIAL
       ret = MPI_Type_dup(sendtype, &(recvtypes[i]));
+#else
+      /* MPI serial does not support MPI_Type_dup() */
+      ret = MPI_Type_contiguous(LOCAL_SZ, MPI_DOUBLE, &(recvtypes[i]));
+#endif
       if(ret == MPI_SUCCESS){
         ret = MPI_Type_commit(&(recvtypes[i]));
       }
       if(ret != MPI_SUCCESS){
-        LOG_RANK0(wrank, "ERROR: Unable to create MPI dup of send type to recv doubles\n");
+        LOG_RANK0(wrank, "ERROR: Unable to create recv type (same as send type) to recv doubles\n");
         return PIO_EINTERNAL;
       }
     }

--- a/util/argparser.cxx
+++ b/util/argparser.cxx
@@ -1,4 +1,3 @@
-#include "mpi.h"
 #include <iostream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
MPI serial library does not support the following functions,
* MPI_Comm_split_type()
* MPI_Type_dup()

The library also requires including the header as a 
"C header file".