### PR TITLE
Enable PIC for shared lib builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,9 @@ endif ()
 # Get the name of the build host
 cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
 
+# Build position independent code (PIC) for shared library builds
+set(CMAKE_POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
+
 # Backwards Compatibility - allow users to define [NETCDF|PNETCDF]_DIR instead
 # of [NetCDF|PnetCDF]_PATH
 # Old NETCDF_DIR variable --> NetCDF_PATH


### PR DESCRIPTION
Explicitly enable PIC for shared library builds